### PR TITLE
refactor: use HugrFuncType/HugrType/HugrSumType

### DIFF
--- a/src/custom/prelude.rs
+++ b/src/custom/prelude.rs
@@ -168,12 +168,12 @@ impl<'c, H: HugrView> CodegenExtsMap<'c, H> {
 mod test {
     use hugr::builder::{Dataflow, DataflowSubContainer};
     use hugr::type_row;
-    use hugr::types::Type;
     use rstest::rstest;
 
     use crate::check_emission;
     use crate::emit::test::SimpleHugrConfig;
     use crate::test::{llvm_ctx, TestContext};
+    use crate::types::HugrType;
 
     use super::*;
 
@@ -248,7 +248,7 @@ mod test {
         let konst1 = ConstExternalSymbol::new("sym1", USIZE_T, true);
         let konst2 = ConstExternalSymbol::new(
             "sym2",
-            Type::new_sum([type_row![USIZE_T, Type::new_unit_sum(3)], type_row![]]),
+            HugrType::new_sum([type_row![USIZE_T, HugrType::new_unit_sum(3)], type_row![]]),
             false,
         );
 

--- a/src/emit.rs
+++ b/src/emit.rs
@@ -14,7 +14,7 @@ use inkwell::{
 };
 use std::{collections::HashSet, rc::Rc};
 
-use crate::types::TypingSession;
+use crate::types::{HugrFuncType, HugrSumType, HugrType, TypingSession};
 
 use crate::{
     custom::CodegenExtsMap,
@@ -69,12 +69,12 @@ impl<'c, H: HugrView> EmitModuleContext<'c, H> {
             pub fn iw_context(&self) -> &'c Context;
         }
         to self.typer.clone() {
-            /// Convert hugr [hugr::types::Type] into an LLVM [Type](BasicTypeEnum).
-            pub fn llvm_type(&self, [self.extensions()], hugr_type: &hugr::types::Type) -> Result<BasicTypeEnum<'c>>;
-            /// Convert a hugr (FunctionType)[hugr::types::FunctionType] into an LLVM [FunctionType].
-            pub fn llvm_func_type(&self, [self.extensions()], hugr_type: &hugr::types::FunctionType) -> Result<FunctionType<'c>>;
-            /// Convert a hugr [hugr::types::SumType] into an LLVM [LLVMSumType].
-            pub fn llvm_sum_type(&self, [self.extensions()], sum_ty: hugr::types::SumType) -> Result<LLVMSumType<'c>>;
+            /// Convert a [HugrType] into an LLVM [Type](BasicTypeEnum).
+            pub fn llvm_type(&self, [self.extensions()], hugr_type: &HugrType) -> Result<BasicTypeEnum<'c>>;
+            /// Convert a [HugrFuncType] into an LLVM [FunctionType].
+            pub fn llvm_func_type(&self, [self.extensions()], hugr_type: &HugrFuncType) -> Result<FunctionType<'c>>;
+            /// Convert a hugr [HugrSumType] into an LLVM [LLVMSumType].
+            pub fn llvm_sum_type(&self, [self.extensions()], sum_ty: HugrSumType) -> Result<LLVMSumType<'c>>;
         }
 
         to self.namer {

--- a/src/emit/func.rs
+++ b/src/emit/func.rs
@@ -15,7 +15,7 @@ use inkwell::{
 };
 use itertools::zip_eq;
 
-use crate::types::TypingSession;
+use crate::types::{HugrFuncType, HugrSumType, HugrType, TypingSession};
 use crate::{custom::CodegenExtsMap, fat::FatNode, types::LLVMSumType};
 use delegate::delegate;
 
@@ -62,12 +62,12 @@ impl<'c, H: HugrView> EmitFuncContext<'c, H> {
             pub fn extensions(&self) ->  Rc<CodegenExtsMap<'c,H>>;
             /// Returns a new [TypingSession].
             pub fn typing_session(&self) -> TypingSession<'c,H>;
-            /// Convert hugr [Type] into an LLVM [Type](BasicTypeEnum).
-            pub fn llvm_type(&self, hugr_type: &hugr::types::Type) -> Result<BasicTypeEnum<'c> >;
-            /// Convert a hugr (FunctionType)[hugr::types::FunctionType] into an LLVM [FunctionType].
-            pub fn llvm_func_type(&self, hugr_type: &hugr::types::FunctionType) -> Result<FunctionType<'c> >;
-            /// Convert a hugr [hugr::types::SumType] into an LLVM [LLVMSumType].
-            pub fn llvm_sum_type(&self, sum_ty: hugr::types::SumType) -> Result<LLVMSumType<'c>>;
+            /// Convert hugr [HugrType] into an LLVM [Type](BasicTypeEnum).
+            pub fn llvm_type(&self, hugr_type: &HugrType) -> Result<BasicTypeEnum<'c> >;
+            /// Convert a [HugrFuncType] into an LLVM [FunctionType].
+            pub fn llvm_func_type(&self, hugr_type: &HugrFuncType) -> Result<FunctionType<'c> >;
+            /// Convert a hugr [HugrSumType] into an LLVM [LLVMSumType].
+            pub fn llvm_sum_type(&self, sum_ty: HugrSumType) -> Result<LLVMSumType<'c>>;
             /// Adds or gets the [FunctionValue] in the [inkwell::module::Module] corresponding to the given [FuncDefn].
             ///
             /// The name of the result may have been mangled.

--- a/src/emit/ops/cfg.rs
+++ b/src/emit/ops/cfg.rs
@@ -232,7 +232,6 @@ mod test {
     use hugr::std_extensions::arithmetic::int_types::{self, INT_TYPES};
     use hugr::type_row;
 
-    use hugr::types::Type;
     use itertools::Itertools as _;
     use rstest::rstest;
 
@@ -241,6 +240,7 @@ mod test {
     use crate::test::{llvm_ctx, TestContext};
 
     use crate::check_emission;
+    use crate::types::HugrType;
 
     #[rstest]
     fn diverse_outputs(mut llvm_ctx: TestContext) {
@@ -301,7 +301,7 @@ mod test {
 
     #[rstest]
     fn nested(llvm_ctx: TestContext) {
-        let t1 = Type::new_unit_sum(3);
+        let t1 = HugrType::new_unit_sum(3);
         let es = ExtensionSet::default();
         let hugr = SimpleHugrConfig::new()
             .with_ins(vec![t1.clone(), BOOL_T])


### PR DESCRIPTION
This gives us a language to distinguish between Hugr Types and LLVM types. It will help with the coming hugr::types::FunctionType -> hugr::types::Signature change