### PR TITLE
ci: Ensure release-plz always pushes as @hugrbot

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -1,10 +1,6 @@
 # Automatic changelog, version bumping, and semver-checks with release-plz for rust projects
 name: Release-plz 🦀
 
-permissions:
-  pull-requests: write
-  contents: write
-
 on:
   push:
     branches:
@@ -19,6 +15,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.HUGRBOT_PAT }}
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
       - name: Run release-plz


### PR DESCRIPTION
This should solve the issue where CI checks wouldn't run in release PRs unless a human triggered an update.

See https://github.com/MarcoIeni/release-plz/blob/main/website/docs/github/token.md#use-a-personal-access-token