### PR TITLE
feat!: Lower string, print, and panic

### DIFF
--- a/src/custom.rs
+++ b/src/custom.rs
@@ -53,7 +53,7 @@ pub trait CodegenExtension<'c, H> {
     /// Return an emitter that will be asked to emit `CustomOp`s that have an
     /// extension that matches `Self.`
     fn emitter<'a>(
-        &self,
+        &'a self,
         context: &'a mut EmitFuncContext<'c, H>,
     ) -> Box<dyn EmitOp<'c, CustomOp, H> + 'a>;
 

--- a/src/custom/snapshots/hugr_llvm__custom__prelude__test__prelude_panic@llvm14.snap
+++ b/src/custom/snapshots/hugr_llvm__custom__prelude__test__prelude_panic@llvm14.snap
@@ -1,0 +1,27 @@
+---
+source: src/custom/prelude.rs
+expression: module.to_string()
+---
+; ModuleID = 'test_context'
+source_filename = "test_context"
+
+@0 = private unnamed_addr constant [6 x i8] c"PANIC\00", align 1
+@prelude.panic_template = private unnamed_addr constant [34 x i8] c"Program panicked (signal %i): %s\0A\00", align 1
+
+define { i16, i16 } @_hl.main.1(i16 %0, i16 %1) {
+alloca_block:
+  br label %entry_block
+
+entry_block:                                      ; preds = %alloca_block
+  %2 = extractvalue { i32, i8* } { i32 42, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @0, i32 0, i32 0) }, 0
+  %3 = extractvalue { i32, i8* } { i32 42, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @0, i32 0, i32 0) }, 1
+  %4 = call i32 (i8*, ...) @printf(i8* getelementptr inbounds ([34 x i8], [34 x i8]* @prelude.panic_template, i32 0, i32 0), i32 %2, i8* %3)
+  call void @abort()
+  %mrv = insertvalue { i16, i16 } undef, i16 0, 0
+  %mrv8 = insertvalue { i16, i16 } %mrv, i16 0, 1
+  ret { i16, i16 } %mrv8
+}
+
+declare i32 @printf(i8*, ...)
+
+declare void @abort()

--- a/src/custom/snapshots/hugr_llvm__custom__prelude__test__prelude_panic@pre-mem2reg@llvm14.snap
+++ b/src/custom/snapshots/hugr_llvm__custom__prelude__test__prelude_panic@pre-mem2reg@llvm14.snap
@@ -1,0 +1,48 @@
+---
+source: src/custom/prelude.rs
+expression: module.to_string()
+---
+; ModuleID = 'test_context'
+source_filename = "test_context"
+
+@0 = private unnamed_addr constant [6 x i8] c"PANIC\00", align 1
+@prelude.panic_template = private unnamed_addr constant [34 x i8] c"Program panicked (signal %i): %s\0A\00", align 1
+
+define { i16, i16 } @_hl.main.1(i16 %0, i16 %1) {
+alloca_block:
+  %"0" = alloca i16, align 2
+  %"1" = alloca i16, align 2
+  %"5_0" = alloca { i32, i8* }, align 8
+  %"2_0" = alloca i16, align 2
+  %"2_1" = alloca i16, align 2
+  %"6_0" = alloca i16, align 2
+  %"6_1" = alloca i16, align 2
+  br label %entry_block
+
+entry_block:                                      ; preds = %alloca_block
+  store { i32, i8* } { i32 42, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @0, i32 0, i32 0) }, { i32, i8* }* %"5_0", align 8
+  store i16 %0, i16* %"2_0", align 2
+  store i16 %1, i16* %"2_1", align 2
+  %"5_01" = load { i32, i8* }, { i32, i8* }* %"5_0", align 8
+  %"2_02" = load i16, i16* %"2_0", align 2
+  %"2_13" = load i16, i16* %"2_1", align 2
+  %2 = extractvalue { i32, i8* } %"5_01", 0
+  %3 = extractvalue { i32, i8* } %"5_01", 1
+  %4 = call i32 (i8*, ...) @printf(i8* getelementptr inbounds ([34 x i8], [34 x i8]* @prelude.panic_template, i32 0, i32 0), i32 %2, i8* %3)
+  call void @abort()
+  store i16 0, i16* %"6_0", align 2
+  store i16 0, i16* %"6_1", align 2
+  %"6_04" = load i16, i16* %"6_0", align 2
+  %"6_15" = load i16, i16* %"6_1", align 2
+  store i16 %"6_04", i16* %"0", align 2
+  store i16 %"6_15", i16* %"1", align 2
+  %"06" = load i16, i16* %"0", align 2
+  %"17" = load i16, i16* %"1", align 2
+  %mrv = insertvalue { i16, i16 } undef, i16 %"06", 0
+  %mrv8 = insertvalue { i16, i16 } %mrv, i16 %"17", 1
+  ret { i16, i16 } %mrv8
+}
+
+declare i32 @printf(i8*, ...)
+
+declare void @abort()

--- a/src/custom/snapshots/hugr_llvm__custom__prelude__test__prelude_print@llvm14.snap
+++ b/src/custom/snapshots/hugr_llvm__custom__prelude__test__prelude_print@llvm14.snap
@@ -1,0 +1,20 @@
+---
+source: src/custom/prelude.rs
+expression: module.to_string()
+---
+; ModuleID = 'test_context'
+source_filename = "test_context"
+
+@0 = private unnamed_addr constant [14 x i8] c"Hello, world!\00", align 1
+@prelude.print_template = private unnamed_addr constant [4 x i8] c"%s\0A\00", align 1
+
+define void @_hl.main.1() {
+alloca_block:
+  br label %entry_block
+
+entry_block:                                      ; preds = %alloca_block
+  %0 = call i32 (i8*, ...) @printf(i8* getelementptr inbounds ([4 x i8], [4 x i8]* @prelude.print_template, i32 0, i32 0), i8* getelementptr inbounds ([14 x i8], [14 x i8]* @0, i32 0, i32 0))
+  ret void
+}
+
+declare i32 @printf(i8*, ...)

--- a/src/custom/snapshots/hugr_llvm__custom__prelude__test__prelude_print@pre-mem2reg@llvm14.snap
+++ b/src/custom/snapshots/hugr_llvm__custom__prelude__test__prelude_print@pre-mem2reg@llvm14.snap
@@ -1,0 +1,23 @@
+---
+source: src/custom/prelude.rs
+expression: module.to_string()
+---
+; ModuleID = 'test_context'
+source_filename = "test_context"
+
+@0 = private unnamed_addr constant [14 x i8] c"Hello, world!\00", align 1
+@prelude.print_template = private unnamed_addr constant [4 x i8] c"%s\0A\00", align 1
+
+define void @_hl.main.1() {
+alloca_block:
+  %"5_0" = alloca i8*, align 8
+  br label %entry_block
+
+entry_block:                                      ; preds = %alloca_block
+  store i8* getelementptr inbounds ([14 x i8], [14 x i8]* @0, i32 0, i32 0), i8** %"5_0", align 8
+  %"5_01" = load i8*, i8** %"5_0", align 8
+  %0 = call i32 (i8*, ...) @printf(i8* getelementptr inbounds ([4 x i8], [4 x i8]* @prelude.print_template, i32 0, i32 0), i8* %"5_01")
+  ret void
+}
+
+declare i32 @printf(i8*, ...)

--- a/src/emit.rs
+++ b/src/emit.rs
@@ -24,6 +24,7 @@ use crate::{
 
 pub mod args;
 pub mod func;
+pub mod libc;
 pub mod namer;
 mod ops;
 

--- a/src/emit/libc.rs
+++ b/src/emit/libc.rs
@@ -1,0 +1,28 @@
+use anyhow::Result;
+use hugr::HugrView;
+use inkwell::{values::BasicMetadataValueEnum, AddressSpace};
+
+use crate::emit::func::EmitFuncContext;
+
+/// Emits a call to the libc `void abort()` function.
+pub fn emit_libc_abort<H: HugrView>(context: &mut EmitFuncContext<H>) -> Result<()> {
+    let iw_ctx = context.typing_session().iw_context();
+    let abort_sig = iw_ctx.void_type().fn_type(&[], false);
+    let abort = context.get_extern_func("abort", abort_sig)?;
+    context.builder().build_call(abort, &[], "")?;
+    Ok(())
+}
+
+/// Emits a call to the libc `int printf(char*, ...)` function.
+pub fn emit_libc_printf<H: HugrView>(
+    context: &mut EmitFuncContext<H>,
+    args: &[BasicMetadataValueEnum],
+) -> Result<()> {
+    let iw_ctx = context.typing_session().iw_context();
+    let str_ty = iw_ctx.i8_type().ptr_type(AddressSpace::default());
+    let printf_sig = iw_ctx.i32_type().fn_type(&[str_ty.into()], true);
+
+    let printf = context.get_extern_func("printf", printf_sig)?;
+    context.builder().build_call(printf, args, "")?;
+    Ok(())
+}


### PR DESCRIPTION
Closes #79.

Adds lowering logic for:
* String type and `ConstString` (c-style)
* Error type and `ConstError`
* Print op (lowers to libc `printf` by default)
* Panic op (lowers to libc `abort` by default)

BREAKING CHANGE: `CodegenExtension::emitter` has a new lifetime bound on the `self` argument. `PreludeCodegen` trait now requires `Clone`.