### PR TITLE
feat: Lower float operations

### DIFF
--- a/src/custom/float.rs
+++ b/src/custom/float.rs
@@ -122,7 +122,7 @@ fn emit_fcmp<'c, H: HugrView>(
 impl<'c, H: HugrView> EmitOp<'c, CustomOp, H> for FloatOpEmitter<'c, '_, H> {
     fn emit(&mut self, args: EmitOpArgs<'c, CustomOp, H>) -> Result<()> {
         let op = FloatOps::from_optype(&args.node().generalise()).ok_or(anyhow!(
-            "LogicOpEmitter: from_optype_failed: {:?}",
+            "FloatOpEmitter: from_optype_failed: {:?}",
             args.node().as_ref()
         ))?;
         // We emit the float comparison variants where NaN is an absorbing value.

--- a/src/custom/float.rs
+++ b/src/custom/float.rs
@@ -1,8 +1,10 @@
 use std::{any::TypeId, collections::HashSet};
 
 use anyhow::{anyhow, Result};
+use hugr::extension::simple_op::MakeExtensionOp;
+use hugr::ops::{constant::CustomConst, CustomOp, Value};
+use hugr::std_extensions::arithmetic::float_ops::FloatOps;
 use hugr::{
-    ops::{constant::CustomConst, CustomOp},
     std_extensions::arithmetic::{
         float_ops,
         float_types::{self, ConstF64, FLOAT64_CUSTOM_TYPE},
@@ -14,11 +16,14 @@ use inkwell::{
     values::{BasicValue, BasicValueEnum},
 };
 
+use crate::emit::emit_value;
+use crate::emit::ops::{emit_custom_binary_op, emit_custom_unary_op};
 use crate::emit::{func::EmitFuncContext, EmitOp, EmitOpArgs, NullEmitLlvm};
 
 use super::{CodegenExtension, CodegenExtsMap};
 
-struct FloatTypesCodegenExtension;
+/// A [CodegenExtension] for the [hugr::std_extensions::arithmetic::float_types] extension.
+pub struct FloatTypesCodegenExtension;
 
 impl<'c, H: HugrView> CodegenExtension<'c, H> for FloatTypesCodegenExtension {
     fn extension(&self) -> hugr::extension::ExtensionId {
@@ -89,20 +94,83 @@ impl<'c, H: HugrView> CodegenExtension<'c, H> for FloatOpsCodegenExtension {
     }
 }
 
-// we allow dead code for now, but once we implement the emitter, we should
-// remove this
-#[allow(dead_code)]
+/// An emitter for [hugr::std_extensions::arithmetic::float_ops] ops.
 struct FloatOpEmitter<'c, 'd, H>(&'d mut EmitFuncContext<'c, H>);
+
+/// Emit a float comparison operation.
+fn emit_fcmp<'c, H: HugrView>(
+    context: &mut EmitFuncContext<'c, H>,
+    args: EmitOpArgs<'c, CustomOp, H>,
+    pred: inkwell::FloatPredicate,
+) -> Result<()> {
+    let true_val = emit_value(context, &Value::true_val())?;
+    let false_val = emit_value(context, &Value::false_val())?;
+
+    emit_custom_binary_op(context, args, |builder, (lhs, rhs), _| {
+        // get result as an i1
+        let r = builder.build_float_compare(
+            pred,
+            lhs.into_float_value(),
+            rhs.into_float_value(),
+            "",
+        )?;
+        // convert to whatever BOOL_T is
+        Ok(vec![builder.build_select(r, true_val, false_val, "")?])
+    })
+}
 
 impl<'c, H: HugrView> EmitOp<'c, CustomOp, H> for FloatOpEmitter<'c, '_, H> {
     fn emit(&mut self, args: EmitOpArgs<'c, CustomOp, H>) -> Result<()> {
-        use hugr::ops::NamedOp;
-        let name = args.node().name();
-        // This looks strange now, but we will add cases for ops piecemeal, as
-        // in the analgous match expression in `IntOpEmitter`.
-        #[allow(clippy::match_single_binding)]
-        match name.as_str() {
-            n => Err(anyhow!("FloatOpEmitter: unknown op: {n}")),
+        let op = FloatOps::from_optype(&args.node().generalise()).ok_or(anyhow!(
+            "LogicOpEmitter: from_optype_failed: {:?}",
+            args.node().as_ref()
+        ))?;
+        // We emit the float comparison variants where NaN is an absorbing value.
+        // Any comparison with NaN is always false.
+        #[allow(clippy::wildcard_in_or_patterns)]
+        match op {
+            FloatOps::feq => emit_fcmp(self.0, args, inkwell::FloatPredicate::OEQ),
+            FloatOps::fne => emit_fcmp(self.0, args, inkwell::FloatPredicate::ONE),
+            FloatOps::flt => emit_fcmp(self.0, args, inkwell::FloatPredicate::OLT),
+            FloatOps::fgt => emit_fcmp(self.0, args, inkwell::FloatPredicate::OGT),
+            FloatOps::fle => emit_fcmp(self.0, args, inkwell::FloatPredicate::OLE),
+            FloatOps::fge => emit_fcmp(self.0, args, inkwell::FloatPredicate::OGE),
+            FloatOps::fadd => emit_custom_binary_op(self.0, args, |builder, (lhs, rhs), _| {
+                Ok(vec![builder
+                    .build_float_add(lhs.into_float_value(), rhs.into_float_value(), "")?
+                    .as_basic_value_enum()])
+            }),
+            FloatOps::fsub => emit_custom_binary_op(self.0, args, |builder, (lhs, rhs), _| {
+                Ok(vec![builder
+                    .build_float_sub(lhs.into_float_value(), rhs.into_float_value(), "")?
+                    .as_basic_value_enum()])
+            }),
+            FloatOps::fneg => emit_custom_unary_op(self.0, args, |builder, v, _| {
+                Ok(vec![builder
+                    .build_float_neg(v.into_float_value(), "")?
+                    .as_basic_value_enum()])
+            }),
+            FloatOps::fmul => emit_custom_binary_op(self.0, args, |builder, (lhs, rhs), _| {
+                Ok(vec![builder
+                    .build_float_mul(lhs.into_float_value(), rhs.into_float_value(), "")?
+                    .as_basic_value_enum()])
+            }),
+            FloatOps::fdiv => emit_custom_binary_op(self.0, args, |builder, (lhs, rhs), _| {
+                Ok(vec![builder
+                    .build_float_div(lhs.into_float_value(), rhs.into_float_value(), "")?
+                    .as_basic_value_enum()])
+            }),
+            // Missing ops, not supported by inkwell
+            FloatOps::fmax
+            | FloatOps::fmin
+            | FloatOps::fabs
+            | FloatOps::ffloor
+            | FloatOps::fceil
+            | FloatOps::ftostring
+            | _ => {
+                let name: &str = op.into();
+                Err(anyhow!("FloatOpEmitter: unimplemented op: {name}"))
+            }
         }
     }
 }

--- a/src/custom/snapshots/hugr_llvm__custom__float__test__fadd@llvm14.snap
+++ b/src/custom/snapshots/hugr_llvm__custom__float__test__fadd@llvm14.snap
@@ -1,0 +1,15 @@
+---
+source: src/custom/float.rs
+expression: module.to_string()
+---
+; ModuleID = 'test_context'
+source_filename = "test_context"
+
+define double @_hl.main.1(double %0, double %1) {
+alloca_block:
+  br label %entry_block
+
+entry_block:                                      ; preds = %alloca_block
+  %2 = fadd double %0, %1
+  ret double %2
+}

--- a/src/custom/snapshots/hugr_llvm__custom__float__test__fadd@pre-mem2reg@llvm14.snap
+++ b/src/custom/snapshots/hugr_llvm__custom__float__test__fadd@pre-mem2reg@llvm14.snap
@@ -1,0 +1,27 @@
+---
+source: src/custom/float.rs
+expression: module.to_string()
+---
+; ModuleID = 'test_context'
+source_filename = "test_context"
+
+define double @_hl.main.1(double %0, double %1) {
+alloca_block:
+  %"0" = alloca double, align 8
+  %"2_0" = alloca double, align 8
+  %"2_1" = alloca double, align 8
+  %"4_0" = alloca double, align 8
+  br label %entry_block
+
+entry_block:                                      ; preds = %alloca_block
+  store double %0, double* %"2_0", align 8
+  store double %1, double* %"2_1", align 8
+  %"2_01" = load double, double* %"2_0", align 8
+  %"2_12" = load double, double* %"2_1", align 8
+  %2 = fadd double %"2_01", %"2_12"
+  store double %2, double* %"4_0", align 8
+  %"4_03" = load double, double* %"4_0", align 8
+  store double %"4_03", double* %"0", align 8
+  %"04" = load double, double* %"0", align 8
+  ret double %"04"
+}

--- a/src/custom/snapshots/hugr_llvm__custom__float__test__fdiv@llvm14.snap
+++ b/src/custom/snapshots/hugr_llvm__custom__float__test__fdiv@llvm14.snap
@@ -1,0 +1,15 @@
+---
+source: src/custom/float.rs
+expression: module.to_string()
+---
+; ModuleID = 'test_context'
+source_filename = "test_context"
+
+define double @_hl.main.1(double %0, double %1) {
+alloca_block:
+  br label %entry_block
+
+entry_block:                                      ; preds = %alloca_block
+  %2 = fdiv double %0, %1
+  ret double %2
+}

--- a/src/custom/snapshots/hugr_llvm__custom__float__test__fdiv@pre-mem2reg@llvm14.snap
+++ b/src/custom/snapshots/hugr_llvm__custom__float__test__fdiv@pre-mem2reg@llvm14.snap
@@ -1,0 +1,27 @@
+---
+source: src/custom/float.rs
+expression: module.to_string()
+---
+; ModuleID = 'test_context'
+source_filename = "test_context"
+
+define double @_hl.main.1(double %0, double %1) {
+alloca_block:
+  %"0" = alloca double, align 8
+  %"2_0" = alloca double, align 8
+  %"2_1" = alloca double, align 8
+  %"4_0" = alloca double, align 8
+  br label %entry_block
+
+entry_block:                                      ; preds = %alloca_block
+  store double %0, double* %"2_0", align 8
+  store double %1, double* %"2_1", align 8
+  %"2_01" = load double, double* %"2_0", align 8
+  %"2_12" = load double, double* %"2_1", align 8
+  %2 = fdiv double %"2_01", %"2_12"
+  store double %2, double* %"4_0", align 8
+  %"4_03" = load double, double* %"4_0", align 8
+  store double %"4_03", double* %"0", align 8
+  %"04" = load double, double* %"0", align 8
+  ret double %"04"
+}

--- a/src/custom/snapshots/hugr_llvm__custom__float__test__feq@llvm14.snap
+++ b/src/custom/snapshots/hugr_llvm__custom__float__test__feq@llvm14.snap
@@ -1,0 +1,16 @@
+---
+source: src/custom/float.rs
+expression: module.to_string()
+---
+; ModuleID = 'test_context'
+source_filename = "test_context"
+
+define { i32, {}, {} } @_hl.main.1(double %0, double %1) {
+alloca_block:
+  br label %entry_block
+
+entry_block:                                      ; preds = %alloca_block
+  %2 = fcmp oeq double %0, %1
+  %3 = select i1 %2, { i32, {}, {} } { i32 1, {} poison, {} undef }, { i32, {}, {} } { i32 0, {} undef, {} poison }
+  ret { i32, {}, {} } %3
+}

--- a/src/custom/snapshots/hugr_llvm__custom__float__test__feq@pre-mem2reg@llvm14.snap
+++ b/src/custom/snapshots/hugr_llvm__custom__float__test__feq@pre-mem2reg@llvm14.snap
@@ -1,0 +1,28 @@
+---
+source: src/custom/float.rs
+expression: module.to_string()
+---
+; ModuleID = 'test_context'
+source_filename = "test_context"
+
+define { i32, {}, {} } @_hl.main.1(double %0, double %1) {
+alloca_block:
+  %"0" = alloca { i32, {}, {} }, align 8
+  %"2_0" = alloca double, align 8
+  %"2_1" = alloca double, align 8
+  %"4_0" = alloca { i32, {}, {} }, align 8
+  br label %entry_block
+
+entry_block:                                      ; preds = %alloca_block
+  store double %0, double* %"2_0", align 8
+  store double %1, double* %"2_1", align 8
+  %"2_01" = load double, double* %"2_0", align 8
+  %"2_12" = load double, double* %"2_1", align 8
+  %2 = fcmp oeq double %"2_01", %"2_12"
+  %3 = select i1 %2, { i32, {}, {} } { i32 1, {} poison, {} undef }, { i32, {}, {} } { i32 0, {} undef, {} poison }
+  store { i32, {}, {} } %3, { i32, {}, {} }* %"4_0", align 4
+  %"4_03" = load { i32, {}, {} }, { i32, {}, {} }* %"4_0", align 4
+  store { i32, {}, {} } %"4_03", { i32, {}, {} }* %"0", align 4
+  %"04" = load { i32, {}, {} }, { i32, {}, {} }* %"0", align 4
+  ret { i32, {}, {} } %"04"
+}

--- a/src/custom/snapshots/hugr_llvm__custom__float__test__fge@llvm14.snap
+++ b/src/custom/snapshots/hugr_llvm__custom__float__test__fge@llvm14.snap
@@ -1,0 +1,16 @@
+---
+source: src/custom/float.rs
+expression: module.to_string()
+---
+; ModuleID = 'test_context'
+source_filename = "test_context"
+
+define { i32, {}, {} } @_hl.main.1(double %0, double %1) {
+alloca_block:
+  br label %entry_block
+
+entry_block:                                      ; preds = %alloca_block
+  %2 = fcmp oge double %0, %1
+  %3 = select i1 %2, { i32, {}, {} } { i32 1, {} poison, {} undef }, { i32, {}, {} } { i32 0, {} undef, {} poison }
+  ret { i32, {}, {} } %3
+}

--- a/src/custom/snapshots/hugr_llvm__custom__float__test__fge@pre-mem2reg@llvm14.snap
+++ b/src/custom/snapshots/hugr_llvm__custom__float__test__fge@pre-mem2reg@llvm14.snap
@@ -1,0 +1,28 @@
+---
+source: src/custom/float.rs
+expression: module.to_string()
+---
+; ModuleID = 'test_context'
+source_filename = "test_context"
+
+define { i32, {}, {} } @_hl.main.1(double %0, double %1) {
+alloca_block:
+  %"0" = alloca { i32, {}, {} }, align 8
+  %"2_0" = alloca double, align 8
+  %"2_1" = alloca double, align 8
+  %"4_0" = alloca { i32, {}, {} }, align 8
+  br label %entry_block
+
+entry_block:                                      ; preds = %alloca_block
+  store double %0, double* %"2_0", align 8
+  store double %1, double* %"2_1", align 8
+  %"2_01" = load double, double* %"2_0", align 8
+  %"2_12" = load double, double* %"2_1", align 8
+  %2 = fcmp oge double %"2_01", %"2_12"
+  %3 = select i1 %2, { i32, {}, {} } { i32 1, {} poison, {} undef }, { i32, {}, {} } { i32 0, {} undef, {} poison }
+  store { i32, {}, {} } %3, { i32, {}, {} }* %"4_0", align 4
+  %"4_03" = load { i32, {}, {} }, { i32, {}, {} }* %"4_0", align 4
+  store { i32, {}, {} } %"4_03", { i32, {}, {} }* %"0", align 4
+  %"04" = load { i32, {}, {} }, { i32, {}, {} }* %"0", align 4
+  ret { i32, {}, {} } %"04"
+}

--- a/src/custom/snapshots/hugr_llvm__custom__float__test__fgt@llvm14.snap
+++ b/src/custom/snapshots/hugr_llvm__custom__float__test__fgt@llvm14.snap
@@ -1,0 +1,16 @@
+---
+source: src/custom/float.rs
+expression: module.to_string()
+---
+; ModuleID = 'test_context'
+source_filename = "test_context"
+
+define { i32, {}, {} } @_hl.main.1(double %0, double %1) {
+alloca_block:
+  br label %entry_block
+
+entry_block:                                      ; preds = %alloca_block
+  %2 = fcmp ogt double %0, %1
+  %3 = select i1 %2, { i32, {}, {} } { i32 1, {} poison, {} undef }, { i32, {}, {} } { i32 0, {} undef, {} poison }
+  ret { i32, {}, {} } %3
+}

--- a/src/custom/snapshots/hugr_llvm__custom__float__test__fgt@pre-mem2reg@llvm14.snap
+++ b/src/custom/snapshots/hugr_llvm__custom__float__test__fgt@pre-mem2reg@llvm14.snap
@@ -1,0 +1,28 @@
+---
+source: src/custom/float.rs
+expression: module.to_string()
+---
+; ModuleID = 'test_context'
+source_filename = "test_context"
+
+define { i32, {}, {} } @_hl.main.1(double %0, double %1) {
+alloca_block:
+  %"0" = alloca { i32, {}, {} }, align 8
+  %"2_0" = alloca double, align 8
+  %"2_1" = alloca double, align 8
+  %"4_0" = alloca { i32, {}, {} }, align 8
+  br label %entry_block
+
+entry_block:                                      ; preds = %alloca_block
+  store double %0, double* %"2_0", align 8
+  store double %1, double* %"2_1", align 8
+  %"2_01" = load double, double* %"2_0", align 8
+  %"2_12" = load double, double* %"2_1", align 8
+  %2 = fcmp ogt double %"2_01", %"2_12"
+  %3 = select i1 %2, { i32, {}, {} } { i32 1, {} poison, {} undef }, { i32, {}, {} } { i32 0, {} undef, {} poison }
+  store { i32, {}, {} } %3, { i32, {}, {} }* %"4_0", align 4
+  %"4_03" = load { i32, {}, {} }, { i32, {}, {} }* %"4_0", align 4
+  store { i32, {}, {} } %"4_03", { i32, {}, {} }* %"0", align 4
+  %"04" = load { i32, {}, {} }, { i32, {}, {} }* %"0", align 4
+  ret { i32, {}, {} } %"04"
+}

--- a/src/custom/snapshots/hugr_llvm__custom__float__test__fle@llvm14.snap
+++ b/src/custom/snapshots/hugr_llvm__custom__float__test__fle@llvm14.snap
@@ -1,0 +1,16 @@
+---
+source: src/custom/float.rs
+expression: module.to_string()
+---
+; ModuleID = 'test_context'
+source_filename = "test_context"
+
+define { i32, {}, {} } @_hl.main.1(double %0, double %1) {
+alloca_block:
+  br label %entry_block
+
+entry_block:                                      ; preds = %alloca_block
+  %2 = fcmp ole double %0, %1
+  %3 = select i1 %2, { i32, {}, {} } { i32 1, {} poison, {} undef }, { i32, {}, {} } { i32 0, {} undef, {} poison }
+  ret { i32, {}, {} } %3
+}

--- a/src/custom/snapshots/hugr_llvm__custom__float__test__fle@pre-mem2reg@llvm14.snap
+++ b/src/custom/snapshots/hugr_llvm__custom__float__test__fle@pre-mem2reg@llvm14.snap
@@ -1,0 +1,28 @@
+---
+source: src/custom/float.rs
+expression: module.to_string()
+---
+; ModuleID = 'test_context'
+source_filename = "test_context"
+
+define { i32, {}, {} } @_hl.main.1(double %0, double %1) {
+alloca_block:
+  %"0" = alloca { i32, {}, {} }, align 8
+  %"2_0" = alloca double, align 8
+  %"2_1" = alloca double, align 8
+  %"4_0" = alloca { i32, {}, {} }, align 8
+  br label %entry_block
+
+entry_block:                                      ; preds = %alloca_block
+  store double %0, double* %"2_0", align 8
+  store double %1, double* %"2_1", align 8
+  %"2_01" = load double, double* %"2_0", align 8
+  %"2_12" = load double, double* %"2_1", align 8
+  %2 = fcmp ole double %"2_01", %"2_12"
+  %3 = select i1 %2, { i32, {}, {} } { i32 1, {} poison, {} undef }, { i32, {}, {} } { i32 0, {} undef, {} poison }
+  store { i32, {}, {} } %3, { i32, {}, {} }* %"4_0", align 4
+  %"4_03" = load { i32, {}, {} }, { i32, {}, {} }* %"4_0", align 4
+  store { i32, {}, {} } %"4_03", { i32, {}, {} }* %"0", align 4
+  %"04" = load { i32, {}, {} }, { i32, {}, {} }* %"0", align 4
+  ret { i32, {}, {} } %"04"
+}

--- a/src/custom/snapshots/hugr_llvm__custom__float__test__flt@llvm14.snap
+++ b/src/custom/snapshots/hugr_llvm__custom__float__test__flt@llvm14.snap
@@ -1,0 +1,16 @@
+---
+source: src/custom/float.rs
+expression: module.to_string()
+---
+; ModuleID = 'test_context'
+source_filename = "test_context"
+
+define { i32, {}, {} } @_hl.main.1(double %0, double %1) {
+alloca_block:
+  br label %entry_block
+
+entry_block:                                      ; preds = %alloca_block
+  %2 = fcmp olt double %0, %1
+  %3 = select i1 %2, { i32, {}, {} } { i32 1, {} poison, {} undef }, { i32, {}, {} } { i32 0, {} undef, {} poison }
+  ret { i32, {}, {} } %3
+}

--- a/src/custom/snapshots/hugr_llvm__custom__float__test__flt@pre-mem2reg@llvm14.snap
+++ b/src/custom/snapshots/hugr_llvm__custom__float__test__flt@pre-mem2reg@llvm14.snap
@@ -1,0 +1,28 @@
+---
+source: src/custom/float.rs
+expression: module.to_string()
+---
+; ModuleID = 'test_context'
+source_filename = "test_context"
+
+define { i32, {}, {} } @_hl.main.1(double %0, double %1) {
+alloca_block:
+  %"0" = alloca { i32, {}, {} }, align 8
+  %"2_0" = alloca double, align 8
+  %"2_1" = alloca double, align 8
+  %"4_0" = alloca { i32, {}, {} }, align 8
+  br label %entry_block
+
+entry_block:                                      ; preds = %alloca_block
+  store double %0, double* %"2_0", align 8
+  store double %1, double* %"2_1", align 8
+  %"2_01" = load double, double* %"2_0", align 8
+  %"2_12" = load double, double* %"2_1", align 8
+  %2 = fcmp olt double %"2_01", %"2_12"
+  %3 = select i1 %2, { i32, {}, {} } { i32 1, {} poison, {} undef }, { i32, {}, {} } { i32 0, {} undef, {} poison }
+  store { i32, {}, {} } %3, { i32, {}, {} }* %"4_0", align 4
+  %"4_03" = load { i32, {}, {} }, { i32, {}, {} }* %"4_0", align 4
+  store { i32, {}, {} } %"4_03", { i32, {}, {} }* %"0", align 4
+  %"04" = load { i32, {}, {} }, { i32, {}, {} }* %"0", align 4
+  ret { i32, {}, {} } %"04"
+}

--- a/src/custom/snapshots/hugr_llvm__custom__float__test__fmul@llvm14.snap
+++ b/src/custom/snapshots/hugr_llvm__custom__float__test__fmul@llvm14.snap
@@ -1,0 +1,15 @@
+---
+source: src/custom/float.rs
+expression: module.to_string()
+---
+; ModuleID = 'test_context'
+source_filename = "test_context"
+
+define double @_hl.main.1(double %0, double %1) {
+alloca_block:
+  br label %entry_block
+
+entry_block:                                      ; preds = %alloca_block
+  %2 = fmul double %0, %1
+  ret double %2
+}

--- a/src/custom/snapshots/hugr_llvm__custom__float__test__fmul@pre-mem2reg@llvm14.snap
+++ b/src/custom/snapshots/hugr_llvm__custom__float__test__fmul@pre-mem2reg@llvm14.snap
@@ -1,0 +1,27 @@
+---
+source: src/custom/float.rs
+expression: module.to_string()
+---
+; ModuleID = 'test_context'
+source_filename = "test_context"
+
+define double @_hl.main.1(double %0, double %1) {
+alloca_block:
+  %"0" = alloca double, align 8
+  %"2_0" = alloca double, align 8
+  %"2_1" = alloca double, align 8
+  %"4_0" = alloca double, align 8
+  br label %entry_block
+
+entry_block:                                      ; preds = %alloca_block
+  store double %0, double* %"2_0", align 8
+  store double %1, double* %"2_1", align 8
+  %"2_01" = load double, double* %"2_0", align 8
+  %"2_12" = load double, double* %"2_1", align 8
+  %2 = fmul double %"2_01", %"2_12"
+  store double %2, double* %"4_0", align 8
+  %"4_03" = load double, double* %"4_0", align 8
+  store double %"4_03", double* %"0", align 8
+  %"04" = load double, double* %"0", align 8
+  ret double %"04"
+}

--- a/src/custom/snapshots/hugr_llvm__custom__float__test__fne@llvm14.snap
+++ b/src/custom/snapshots/hugr_llvm__custom__float__test__fne@llvm14.snap
@@ -1,0 +1,16 @@
+---
+source: src/custom/float.rs
+expression: module.to_string()
+---
+; ModuleID = 'test_context'
+source_filename = "test_context"
+
+define { i32, {}, {} } @_hl.main.1(double %0, double %1) {
+alloca_block:
+  br label %entry_block
+
+entry_block:                                      ; preds = %alloca_block
+  %2 = fcmp one double %0, %1
+  %3 = select i1 %2, { i32, {}, {} } { i32 1, {} poison, {} undef }, { i32, {}, {} } { i32 0, {} undef, {} poison }
+  ret { i32, {}, {} } %3
+}

--- a/src/custom/snapshots/hugr_llvm__custom__float__test__fne@pre-mem2reg@llvm14.snap
+++ b/src/custom/snapshots/hugr_llvm__custom__float__test__fne@pre-mem2reg@llvm14.snap
@@ -1,0 +1,28 @@
+---
+source: src/custom/float.rs
+expression: module.to_string()
+---
+; ModuleID = 'test_context'
+source_filename = "test_context"
+
+define { i32, {}, {} } @_hl.main.1(double %0, double %1) {
+alloca_block:
+  %"0" = alloca { i32, {}, {} }, align 8
+  %"2_0" = alloca double, align 8
+  %"2_1" = alloca double, align 8
+  %"4_0" = alloca { i32, {}, {} }, align 8
+  br label %entry_block
+
+entry_block:                                      ; preds = %alloca_block
+  store double %0, double* %"2_0", align 8
+  store double %1, double* %"2_1", align 8
+  %"2_01" = load double, double* %"2_0", align 8
+  %"2_12" = load double, double* %"2_1", align 8
+  %2 = fcmp one double %"2_01", %"2_12"
+  %3 = select i1 %2, { i32, {}, {} } { i32 1, {} poison, {} undef }, { i32, {}, {} } { i32 0, {} undef, {} poison }
+  store { i32, {}, {} } %3, { i32, {}, {} }* %"4_0", align 4
+  %"4_03" = load { i32, {}, {} }, { i32, {}, {} }* %"4_0", align 4
+  store { i32, {}, {} } %"4_03", { i32, {}, {} }* %"0", align 4
+  %"04" = load { i32, {}, {} }, { i32, {}, {} }* %"0", align 4
+  ret { i32, {}, {} } %"04"
+}

--- a/src/custom/snapshots/hugr_llvm__custom__float__test__fneg@llvm14.snap
+++ b/src/custom/snapshots/hugr_llvm__custom__float__test__fneg@llvm14.snap
@@ -1,0 +1,15 @@
+---
+source: src/custom/float.rs
+expression: module.to_string()
+---
+; ModuleID = 'test_context'
+source_filename = "test_context"
+
+define double @_hl.main.1(double %0) {
+alloca_block:
+  br label %entry_block
+
+entry_block:                                      ; preds = %alloca_block
+  %1 = fneg double %0
+  ret double %1
+}

--- a/src/custom/snapshots/hugr_llvm__custom__float__test__fneg@pre-mem2reg@llvm14.snap
+++ b/src/custom/snapshots/hugr_llvm__custom__float__test__fneg@pre-mem2reg@llvm14.snap
@@ -1,0 +1,24 @@
+---
+source: src/custom/float.rs
+expression: module.to_string()
+---
+; ModuleID = 'test_context'
+source_filename = "test_context"
+
+define double @_hl.main.1(double %0) {
+alloca_block:
+  %"0" = alloca double, align 8
+  %"2_0" = alloca double, align 8
+  %"4_0" = alloca double, align 8
+  br label %entry_block
+
+entry_block:                                      ; preds = %alloca_block
+  store double %0, double* %"2_0", align 8
+  %"2_01" = load double, double* %"2_0", align 8
+  %1 = fneg double %"2_01"
+  store double %1, double* %"4_0", align 8
+  %"4_02" = load double, double* %"4_0", align 8
+  store double %"4_02", double* %"0", align 8
+  %"03" = load double, double* %"0", align 8
+  ret double %"03"
+}

--- a/src/custom/snapshots/hugr_llvm__custom__float__test__fsub@llvm14.snap
+++ b/src/custom/snapshots/hugr_llvm__custom__float__test__fsub@llvm14.snap
@@ -1,0 +1,15 @@
+---
+source: src/custom/float.rs
+expression: module.to_string()
+---
+; ModuleID = 'test_context'
+source_filename = "test_context"
+
+define double @_hl.main.1(double %0, double %1) {
+alloca_block:
+  br label %entry_block
+
+entry_block:                                      ; preds = %alloca_block
+  %2 = fsub double %0, %1
+  ret double %2
+}

--- a/src/custom/snapshots/hugr_llvm__custom__float__test__fsub@pre-mem2reg@llvm14.snap
+++ b/src/custom/snapshots/hugr_llvm__custom__float__test__fsub@pre-mem2reg@llvm14.snap
@@ -1,0 +1,27 @@
+---
+source: src/custom/float.rs
+expression: module.to_string()
+---
+; ModuleID = 'test_context'
+source_filename = "test_context"
+
+define double @_hl.main.1(double %0, double %1) {
+alloca_block:
+  %"0" = alloca double, align 8
+  %"2_0" = alloca double, align 8
+  %"2_1" = alloca double, align 8
+  %"4_0" = alloca double, align 8
+  br label %entry_block
+
+entry_block:                                      ; preds = %alloca_block
+  store double %0, double* %"2_0", align 8
+  store double %1, double* %"2_1", align 8
+  %"2_01" = load double, double* %"2_0", align 8
+  %"2_12" = load double, double* %"2_1", align 8
+  %2 = fsub double %"2_01", %"2_12"
+  store double %2, double* %"4_0", align 8
+  %"4_03" = load double, double* %"4_0", align 8
+  store double %"4_03", double* %"0", align 8
+  %"04" = load double, double* %"0", align 8
+  ret double %"04"
+}

--- a/src/emit.rs
+++ b/src/emit.rs
@@ -26,7 +26,7 @@ pub mod args;
 pub mod func;
 pub mod libc;
 pub mod namer;
-mod ops;
+pub mod ops;
 
 pub use args::EmitOpArgs;
 pub use func::{EmitFuncContext, RowPromise};

--- a/src/emit/ops.rs
+++ b/src/emit/ops.rs
@@ -446,7 +446,7 @@ where
 {
     let [inp] = TryInto::<[_; 1]>::try_into(args.inputs).map_err(|v| {
         anyhow!(
-            "emit_custom_1_to_1_op: expected exactly one input, got {}",
+            "emit_custom_unary_op: expected exactly one input, got {}",
             v.len()
         )
     })?;
@@ -456,7 +456,7 @@ where
         || zip_eq(res.iter(), out_types).any(|(a, b)| a.get_type() != b)
     {
         return Err(anyhow!(
-            "emit_custom_1_to_1_op: expected outputs of types {:?}, got {:?}",
+            "emit_custom_unary_op: expected outputs of types {:?}, got {:?}",
             args.outputs.get_types().collect_vec(),
             res.iter().map(BasicValueEnum::get_type).collect_vec()
         ));
@@ -487,13 +487,13 @@ where
 {
     let [lhs, rhs] = TryInto::<[_; 2]>::try_into(args.inputs).map_err(|v| {
         anyhow!(
-            "emit_custom_2_to_1_op: expected exactly 2 inputs, got {}",
+            "emit_custom_binary_op: expected exactly 2 inputs, got {}",
             v.len()
         )
     })?;
     if lhs.get_type() != rhs.get_type() {
         return Err(anyhow!(
-            "emit_custom_2_to_1_op: expected inputs of the same type, got {} and {}",
+            "emit_custom_binary_op: expected inputs of the same type, got {} and {}",
             lhs.get_type(),
             rhs.get_type()
         ));
@@ -503,7 +503,7 @@ where
     if res.len() != out_types.len() || zip_eq(res.iter(), out_types).any(|(a, b)| a.get_type() != b)
     {
         return Err(anyhow!(
-            "emit_custom_2_to_1_op: expected outputs of types {:?}, got {:?}",
+            "emit_custom_binary_op: expected outputs of types {:?}, got {:?}",
             args.outputs.get_types().collect_vec(),
             res.iter().map(BasicValueEnum::get_type).collect_vec()
         ));

--- a/src/emit/ops.rs
+++ b/src/emit/ops.rs
@@ -1,18 +1,19 @@
 use anyhow::{anyhow, Result};
+use hugr::ops::{
+    constant::Sum, Call, CallIndirect, Case, Conditional, Const, CustomOp, Input, LoadConstant,
+    LoadFunction, MakeTuple, OpTag, OpTrait, OpType, Output, Tag, UnpackTuple, Value, CFG,
+};
 use hugr::{
     hugr::views::SiblingGraph,
-    ops::{
-        constant::Sum, Call, CallIndirect, Case, Conditional, Const, Input, LoadConstant,
-        LoadFunction, MakeTuple, OpTag, OpTrait, OpType, Output, Tag, UnpackTuple, Value, CFG,
-    },
     types::{SumType, Type, TypeEnum},
     HugrView, NodeIndex,
 };
+use inkwell::types::BasicTypeEnum;
 use inkwell::{
     builder::Builder,
     values::{BasicValueEnum, CallableValue},
 };
-use itertools::Itertools;
+use itertools::{zip_eq, Itertools};
 use petgraph::visit::Walker;
 
 use crate::{fat::FatExt as _, sum::LLVMSumValue};
@@ -420,4 +421,92 @@ fn emit_optype<'c, H: HugrView>(
 
         _ => Err(anyhow!("Invalid child for Dataflow Parent: {node}")),
     }
+}
+
+/// Emit a custom operation with a single input.
+///
+/// # Arguments
+///
+/// * `context` - The context in which to emit the operation.
+/// * `args` - The arguments to the operation.
+/// * `go` - The operation to build the result given a [`Builder`], the input,
+///   and an iterator over the expected output types.
+pub(crate) fn emit_custom_unary_op<'c, H, F>(
+    context: &mut EmitFuncContext<'c, H>,
+    args: EmitOpArgs<'c, CustomOp, H>,
+    go: F,
+) -> Result<()>
+where
+    H: HugrView,
+    F: FnOnce(
+        &Builder<'c>,
+        BasicValueEnum<'c>,
+        &[BasicTypeEnum<'c>],
+    ) -> Result<Vec<BasicValueEnum<'c>>>,
+{
+    let [inp] = TryInto::<[_; 1]>::try_into(args.inputs).map_err(|v| {
+        anyhow!(
+            "emit_custom_1_to_1_op: expected exactly one input, got {}",
+            v.len()
+        )
+    })?;
+    let out_types = args.outputs.get_types().collect_vec();
+    let res = go(context.builder(), inp, &out_types)?;
+    if res.len() != args.outputs.len()
+        || zip_eq(res.iter(), out_types).any(|(a, b)| a.get_type() != b)
+    {
+        return Err(anyhow!(
+            "emit_custom_1_to_1_op: expected outputs of types {:?}, got {:?}",
+            args.outputs.get_types().collect_vec(),
+            res.iter().map(BasicValueEnum::get_type).collect_vec()
+        ));
+    }
+    args.outputs.finish(context.builder(), res)
+}
+
+/// Emit a custom operation with two inputs of the same type.
+///
+/// # Arguments
+///
+/// * `context` - The context in which to emit the operation.
+/// * `args` - The arguments to the operation.
+/// * `go` - The operation to build the result given a [`Builder`], the two
+///   inputs, and an iterator over the expected output types.
+pub(crate) fn emit_custom_binary_op<'c, H, F>(
+    context: &mut EmitFuncContext<'c, H>,
+    args: EmitOpArgs<'c, CustomOp, H>,
+    go: F,
+) -> Result<()>
+where
+    H: HugrView,
+    F: FnOnce(
+        &Builder<'c>,
+        (BasicValueEnum<'c>, BasicValueEnum<'c>),
+        &[BasicTypeEnum<'c>],
+    ) -> Result<Vec<BasicValueEnum<'c>>>,
+{
+    let [lhs, rhs] = TryInto::<[_; 2]>::try_into(args.inputs).map_err(|v| {
+        anyhow!(
+            "emit_custom_2_to_1_op: expected exactly 2 inputs, got {}",
+            v.len()
+        )
+    })?;
+    if lhs.get_type() != rhs.get_type() {
+        return Err(anyhow!(
+            "emit_custom_2_to_1_op: expected inputs of the same type, got {} and {}",
+            lhs.get_type(),
+            rhs.get_type()
+        ));
+    }
+    let out_types = args.outputs.get_types().collect_vec();
+    let res = go(context.builder(), (lhs, rhs), &out_types)?;
+    if res.len() != out_types.len() || zip_eq(res.iter(), out_types).any(|(a, b)| a.get_type() != b)
+    {
+        return Err(anyhow!(
+            "emit_custom_2_to_1_op: expected outputs of types {:?}, got {:?}",
+            args.outputs.get_types().collect_vec(),
+            res.iter().map(BasicValueEnum::get_type).collect_vec()
+        ));
+    }
+    args.outputs.finish(context.builder(), res)
 }


### PR DESCRIPTION
Closes #21.

There are still some missing operations that should be supported by llvm, but are not binded by inkwell :/

I modified the `check_emissions!` macro to work inside rstest's `#[case]`s