### PR TITLE
feat: Add emitters for int <-> float/usize conversions

### DIFF
--- a/src/custom.rs
+++ b/src/custom.rs
@@ -21,6 +21,7 @@ use crate::{
 
 use super::emit::EmitOp;
 
+pub mod conversions;
 pub mod float;
 pub mod int;
 pub mod logic;

--- a/src/custom/conversions.rs
+++ b/src/custom/conversions.rs
@@ -284,27 +284,27 @@ mod test {
     #[rstest]
     #[case("convert_u", 4)]
     #[case("convert_s", 5)]
-    fn test_convert(mut llvm_ctx: TestContext, #[case] op_name: &str, #[case] width: u8) -> () {
+    fn test_convert(mut llvm_ctx: TestContext, #[case] op_name: &str, #[case] log_width: u8) -> () {
         llvm_ctx.add_extensions(add_int_extensions);
         llvm_ctx.add_extensions(add_float_extensions);
         llvm_ctx.add_extensions(add_conversions_extension);
-        let in_ty = INT_TYPES[width as usize].clone();
+        let in_ty = INT_TYPES[log_width as usize].clone();
         let out_ty = FLOAT64_TYPE;
-        let hugr = test_conversion_op(op_name, in_ty, out_ty, width);
+        let hugr = test_conversion_op(op_name, in_ty, out_ty, log_width);
         check_emission!(op_name, hugr, llvm_ctx);
     }
 
     #[rstest]
     #[case("trunc_u", 6)]
     #[case("trunc_s", 5)]
-    fn test_truncation(mut llvm_ctx: TestContext, #[case] op_name: &str, #[case] width: u8) -> () {
+    fn test_truncation(mut llvm_ctx: TestContext, #[case] op_name: &str, #[case] log_width: u8) -> () {
         llvm_ctx.add_extensions(add_int_extensions);
         llvm_ctx.add_extensions(add_float_extensions);
         llvm_ctx.add_extensions(add_conversions_extension);
         llvm_ctx.add_extensions(add_default_prelude_extensions);
         let in_ty = FLOAT64_TYPE;
-        let out_ty = sum_with_error(INT_TYPES[width as usize].clone());
-        let hugr = test_conversion_op(op_name, in_ty, out_ty.into(), width);
+        let out_ty = sum_with_error(INT_TYPES[log_width as usize].clone());
+        let hugr = test_conversion_op(op_name, in_ty, out_ty.into(), log_width);
         check_emission!(op_name, hugr, llvm_ctx);
     }
 

--- a/src/custom/conversions.rs
+++ b/src/custom/conversions.rs
@@ -168,7 +168,7 @@ impl<'c, H: HugrView> ConversionsEmitter<'c, '_, H> {
             // to the result of our overflow check.
             // This should look the same as the appropriate sum instance.
             let val = sum_ty
-                .get_poison()
+                .get_undef()
                 .as_basic_value_enum()
                 .into_struct_value();
             let val = ctx.builder().build_insert_value(val, e, 1, "error val")?;

--- a/src/custom/conversions.rs
+++ b/src/custom/conversions.rs
@@ -46,7 +46,7 @@ impl<'c, H: HugrView> ConversionsEmitter<'c, '_, H> {
             6 => (64, (i64::MIN, i64::MAX), u64::MAX),
             m => {
                 return Err(anyhow!(
-                    "IntTypesCodegenExtension: unsupported log_width: {}",
+                    "ConversionEmitter: unsupported log_width: {}",
                     m
                 ))
             }
@@ -98,6 +98,7 @@ impl<'c, H: HugrView> ConversionsEmitter<'c, '_, H> {
                 "within_lower_bound",
             )?;
 
+            // N.B. If the float value is NaN, we will never succeed.
             let success = ctx
                 .builder()
                 .build_and(within_upper_bound, within_lower_bound, "success")
@@ -211,7 +212,7 @@ impl<'c, H: HugrView> CodegenExtension<'c, H> for ConversionsCodegenExtension {
         hugr_type: &CustomType,
     ) -> Result<BasicTypeEnum<'c>> {
         Err(anyhow!(
-            "IntOpsCodegenExtension: unsupported type: {}",
+            "ConversionEmitter: unsupported type: {}",
             hugr_type
         ))
     }

--- a/src/custom/conversions.rs
+++ b/src/custom/conversions.rs
@@ -45,10 +45,10 @@ impl<'c, H: HugrView> ConversionsEmitter<'c, '_, H> {
         // Note: This logic is copied from `llvm_type` in the IntTypes
         // extension. We need to have a common source of truth for this.
         let (width, int_max_value_s, int_max_value_u) = match log_width {
-            0..=3 => Ok((8, i8::max_value() as u64, u8::max_value() as u64)),
-            4 => Ok((16, i16::max_value() as u64, u16::max_value() as u64)),
-            5 => Ok((32, i32::max_value() as u64, u32::max_value() as u64)),
-            6 => Ok((64, i64::max_value() as u64, u64::max_value())),
+            0..=3 => Ok((8, i8::MAX as u64, u8::MAX as u64)),
+            4 => Ok((16, i16::MAX as u64, u16::MAX as u64)),
+            5 => Ok((32, i32::MAX as u64, u32::MAX as u64)),
+            6 => Ok((64, i64::MAX as u64, u64::MAX)),
             m => Err(anyhow!(
                 "IntTypesCodegenExtension: unsupported log_width: {}",
                 m
@@ -79,9 +79,9 @@ impl<'c, H: HugrView> ConversionsEmitter<'c, '_, H> {
             // make the maximum int and convert to a float, then compare
             // with the function input.
             let int_max = if signed {
-                int_ty.const_int(int_max_value_s as u64, false)
+                int_ty.const_int(int_max_value_s, false)
             } else {
-                int_ty.const_int(int_max_value_u as u64, false)
+                int_ty.const_int(int_max_value_u, false)
             };
 
             let flt_int_max = if signed {
@@ -123,7 +123,11 @@ impl<'c, H: HugrView> ConversionsEmitter<'c, '_, H> {
                 flt_int_max,
                 "conversion_valid",
             )?;
-            let success = ctx.builder().build_int_s_extend(success, ctx.iw_context().i32_type(), "conversion_valid_i32")?;
+            let success = ctx.builder().build_int_s_extend(
+                success,
+                ctx.iw_context().i32_type(),
+                "conversion_valid_i32",
+            )?;
 
             // Perform the conversion unconditionally, which will result
             // in a poison value if the input was too large. We will

--- a/src/custom/conversions.rs
+++ b/src/custom/conversions.rs
@@ -45,15 +45,17 @@ impl<'c, H: HugrView> ConversionsEmitter<'c, '_, H> {
         // Note: This logic is copied from `llvm_type` in the IntTypes
         // extension. We need to have a common source of truth for this.
         let (width, int_max_value_s, int_max_value_u) = match log_width {
-            0..=3 => Ok((8, i8::MAX as u64, u8::MAX as u64)),
-            4 => Ok((16, i16::MAX as u64, u16::MAX as u64)),
-            5 => Ok((32, i32::MAX as u64, u32::MAX as u64)),
-            6 => Ok((64, i64::MAX as u64, u64::MAX)),
-            m => Err(anyhow!(
-                "IntTypesCodegenExtension: unsupported log_width: {}",
-                m
-            )),
-        }?;
+            0..=3 => (8, i8::MAX as u64, u8::MAX as u64),
+            4 => (16, i16::MAX as u64, u16::MAX as u64),
+            5 => (32, i32::MAX as u64, u32::MAX as u64),
+            6 => (64, i64::MAX as u64, u64::MAX),
+            m => {
+                return Err(anyhow!(
+                    "IntTypesCodegenExtension: unsupported log_width: {}",
+                    m
+                ))
+            }
+        };
 
         let hugr_int_ty = INT_TYPES[log_width as usize].clone();
         let int_ty = self

--- a/src/custom/conversions.rs
+++ b/src/custom/conversions.rs
@@ -85,8 +85,8 @@ impl<'c, H: HugrView> EmitOp<'c, ExtensionOp, H> for ConversionsEmitter<'c, '_, 
 
                     let flt_int_max = if signed {
                         let abs_name = &format!("llvm.abs.i{}", width);
-                        let abs_intr = Intrinsic::find(&abs_name)
-                            .expect(&format!("Couldn't find {} intrinsic", abs_name));
+                        let abs_intr = Intrinsic::find(abs_name)
+                            .expect("Couldn't find int abs intrinsic");
                         let abs = abs_intr
                             .get_declaration(
                                 ctx.get_current_module(),

--- a/src/custom/conversions.rs
+++ b/src/custom/conversions.rs
@@ -85,8 +85,8 @@ impl<'c, H: HugrView> EmitOp<'c, ExtensionOp, H> for ConversionsEmitter<'c, '_, 
 
                     let flt_int_max = if signed {
                         let abs_name = &format!("llvm.abs.i{}", width);
-                        let abs_intr = Intrinsic::find(abs_name)
-                            .expect("Couldn't find int abs intrinsic");
+                        let abs_intr =
+                            Intrinsic::find(abs_name).expect("Couldn't find int abs intrinsic");
                         let abs = abs_intr
                             .get_declaration(
                                 ctx.get_current_module(),

--- a/src/custom/conversions.rs
+++ b/src/custom/conversions.rs
@@ -26,7 +26,6 @@ use crate::{
         ops::{emit_custom_unary_op, emit_value},
         EmitOp, EmitOpArgs,
     },
-    sum::LLVMSumType,
     types::TypingSession,
 };
 

--- a/src/custom/conversions.rs
+++ b/src/custom/conversions.rs
@@ -68,7 +68,7 @@ impl<'c, H: HugrView> EmitOp<'c, ExtensionOp, H> for ConversionsEmitter<'c, '_, 
                 let width = int_ty.get_bit_width();
                 let log_width = log2(width).unwrap();
                 let hugr_sum_ty = sum_with_error(vec![INT_TYPES[log_width as usize].clone()]);
-                let sum_ty = LLVMSumType::try_new(&self.0.typing_session(), hugr_sum_ty)?;
+                let sum_ty = self.0.typing_session().llvm_sum_type(hugr_sum_ty)?;
                 emit_custom_unary_op(self.0, args, |ctx, arg, _| {
                     let trunc_result = if conversion_op == ConvertOpDef::trunc_u {
                         ctx.builder().build_float_to_unsigned_int(

--- a/src/custom/conversions.rs
+++ b/src/custom/conversions.rs
@@ -91,14 +91,15 @@ impl<'c, H: HugrView> ConversionsEmitter<'c, '_, H> {
                     .get_declaration(ctx.get_current_module(), &[int_ty.as_basic_type_enum()])
                     .unwrap();
 
-                let fabs_call = ctx
+                let const_false = ctx.iw_context().bool_type().const_zero().as_basic_value_enum();
+                let abs_call = ctx
                     .builder()
-                    .build_call(abs, &[int_max.into()], "max_int_pos")?
+                    .build_call(abs, &[int_max.into(), const_false.into()], "max_int_pos")?
                     .as_any_value_enum()
                     .into_int_value();
 
                 ctx.builder().build_signed_int_to_float(
-                    fabs_call,
+                    abs_call,
                     ctx.iw_context().f64_type(),
                     "max_flt_pos",
                 )

--- a/src/custom/conversions.rs
+++ b/src/custom/conversions.rs
@@ -1,0 +1,246 @@
+use super::{CodegenExtension, CodegenExtsMap};
+
+use anyhow::{anyhow, Result};
+
+use hugr::{
+    extension::{
+        prelude::{sum_with_error, ConstError},
+        simple_op::MakeExtensionOp,
+        ExtensionId,
+    },
+    ops::{constant::Value, custom::ExtensionOp},
+    std_extensions::arithmetic::{
+        conversions::{self, ConvertOpDef},
+        int_types::INT_TYPES,
+    },
+    types::CustomType,
+    HugrView,
+};
+
+use inkwell::types::BasicTypeEnum;
+use inkwell::values::{AnyValue, BasicValue};
+
+use crate::{
+    emit::{
+        func::EmitFuncContext,
+        ops::{emit_custom_unary_op, emit_value},
+        EmitOp, EmitOpArgs,
+    },
+    sum::LLVMSumType,
+    types::TypingSession,
+};
+
+struct ConversionsEmitter<'c, 'd, H>(&'d mut EmitFuncContext<'c, H>);
+
+fn log2(m: u32) -> Option<u8> {
+    if m == 1 {
+        Some(0)
+    } else if m % 2 == 0 {
+        let n = log2(m / 2)?;
+        Some(n + 1)
+    } else {
+        None
+    }
+}
+
+impl<'c, H: HugrView> EmitOp<'c, ExtensionOp, H> for ConversionsEmitter<'c, '_, H> {
+    fn emit(&mut self, args: EmitOpArgs<'c, ExtensionOp, H>) -> Result<()> {
+        let conversion_op = ConvertOpDef::from_optype(&args.node().generalise()).ok_or(anyhow!(
+            "ConversionsEmitter from_optype failed: {:?}",
+            args.node().as_ref()
+        ))?;
+
+        match conversion_op {
+            ConvertOpDef::trunc_u | ConvertOpDef::trunc_s => {
+                let out_sum_ty = args
+                    .outputs
+                    .get_types()
+                    .last()
+                    .map(|a| a.into_struct_type())
+                    .unwrap();
+                let int_ty = out_sum_ty
+                    .get_field_type_at_index(2)
+                    .unwrap()
+                    .into_struct_type()
+                    .get_field_type_at_index(0)
+                    .unwrap()
+                    .into_int_type();
+                let width = int_ty.get_bit_width();
+                let log_width = log2(width).unwrap();
+                let hugr_sum_ty = sum_with_error(vec![INT_TYPES[log_width as usize].clone()]);
+                let sum_ty = LLVMSumType::try_new(&self.0.typing_session(), hugr_sum_ty)?;
+                emit_custom_unary_op(self.0, args, |ctx, arg, _| {
+                    let trunc_result = if conversion_op == ConvertOpDef::trunc_u {
+                        ctx.builder().build_float_to_unsigned_int(
+                            arg.into_float_value(),
+                            int_ty,
+                            "",
+                        )
+                    } else {
+                        // Otherwise it's ConvertOpDef::trunc_s
+                        ctx.builder()
+                            .build_float_to_signed_int(arg.into_float_value(), int_ty, "")
+                    }?
+                    .as_basic_value_enum();
+                    let optional_result = if trunc_result.is_poison() {
+                        let trunc_err_hugr_val = Value::extension(ConstError::new(
+                            2,
+                            format!(
+                                "Float value too big to convert to int of given width ({})",
+                                width
+                            ),
+                        ));
+                        let e = emit_value(ctx, &trunc_err_hugr_val)?;
+                        sum_ty.build_tag(ctx.builder(), 0, vec![e])
+                    } else {
+                        sum_ty.build_tag(ctx.builder(), 1, vec![trunc_result])
+                    }?;
+
+                    Ok(vec![optional_result])
+                })
+            }
+
+            ConvertOpDef::convert_u => emit_custom_unary_op(self.0, args, |ctx, arg, out_tys| {
+                let out_ty = out_tys.last().unwrap();
+                Ok(vec![ctx
+                    .builder()
+                    .build_unsigned_int_to_float(
+                        arg.into_int_value(),
+                        out_ty.into_float_type(),
+                        "",
+                    )?
+                    .as_basic_value_enum()])
+            }),
+
+            ConvertOpDef::convert_s => emit_custom_unary_op(self.0, args, |ctx, arg, out_tys| {
+                let out_ty = out_tys.last().unwrap();
+                Ok(vec![ctx
+                    .builder()
+                    .build_signed_int_to_float(arg.into_int_value(), out_ty.into_float_type(), "")?
+                    .as_basic_value_enum()])
+            }),
+            _ => Err(anyhow!(
+                "Conversion op not implemented: {:?}",
+                args.node().as_ref()
+            )),
+        }
+        //Ok(())
+    }
+}
+
+pub struct ConversionsCodegenExtension;
+
+impl<'c, H: HugrView> CodegenExtension<'c, H> for ConversionsCodegenExtension {
+    fn extension(&self) -> ExtensionId {
+        conversions::EXTENSION_ID
+    }
+
+    fn llvm_type<'d>(
+        &self,
+        _context: &TypingSession<'c, H>,
+        hugr_type: &CustomType,
+    ) -> Result<BasicTypeEnum<'c>> {
+        Err(anyhow!(
+            "IntOpsCodegenExtension: unsupported type: {}",
+            hugr_type
+        ))
+    }
+
+    fn emitter<'a>(
+        &self,
+        context: &'a mut EmitFuncContext<'c, H>,
+    ) -> Box<dyn EmitOp<'c, ExtensionOp, H> + 'a> {
+        Box::new(ConversionsEmitter(context))
+    }
+}
+
+pub fn add_conversions_extension<H: HugrView>(cem: CodegenExtsMap<'_, H>) -> CodegenExtsMap<'_, H> {
+    cem.add_cge(ConversionsCodegenExtension)
+}
+
+#[cfg(test)]
+mod test {
+
+    use super::*;
+
+    use crate::check_emission;
+    use crate::custom::{
+        float::add_float_extensions, int::add_int_extensions,
+        prelude::add_default_prelude_extensions,
+    };
+    use crate::emit::test::SimpleHugrConfig;
+    use crate::test::{llvm_ctx, TestContext};
+    use hugr::{
+        builder::{Dataflow, DataflowSubContainer},
+        std_extensions::arithmetic::{
+            conversions::{CONVERT_OPS_REGISTRY, EXTENSION},
+            float_types::FLOAT64_TYPE,
+            int_types::INT_TYPES,
+        },
+        types::Type,
+        Hugr,
+    };
+    use rstest::rstest;
+
+    fn test_conversion_op(
+        name: impl AsRef<str>,
+        in_type: Type,
+        out_type: Type,
+        int_width: u8,
+    ) -> Hugr {
+        SimpleHugrConfig::new()
+            .with_ins(vec![in_type.clone()])
+            .with_outs(vec![out_type.clone()])
+            .with_extensions(CONVERT_OPS_REGISTRY.clone())
+            .finish(|mut hugr_builder| {
+                let [in1] = hugr_builder.input_wires_arr();
+                let ext_op = EXTENSION
+                    .instantiate_extension_op(
+                        name.as_ref(),
+                        [(int_width as u64).into()],
+                        &CONVERT_OPS_REGISTRY,
+                    )
+                    .unwrap();
+                let outputs = hugr_builder
+                    .add_dataflow_op(ext_op, [in1])
+                    .unwrap()
+                    .outputs();
+                hugr_builder.finish_with_outputs(outputs).unwrap()
+            })
+    }
+
+    #[rstest]
+    #[case(256, Some(8))]
+    #[case(63, None)]
+    #[case(1, Some(0))]
+    fn log(#[case] m: u32, #[case] expected: Option<u8>) {
+        assert_eq!(log2(m), expected)
+    }
+
+    #[rstest]
+    #[case("convert_u", 4)]
+    #[case("convert_s", 5)]
+    fn test_convert(mut llvm_ctx: TestContext, #[case] op_name: &str, #[case] width: u8) -> () {
+        llvm_ctx.add_extensions(add_int_extensions);
+        llvm_ctx.add_extensions(add_float_extensions);
+        llvm_ctx.add_extensions(add_conversions_extension);
+        let in_ty = INT_TYPES[width as usize].clone();
+        let out_ty = FLOAT64_TYPE;
+        let hugr = test_conversion_op(op_name, in_ty, out_ty, width);
+        check_emission!(op_name, hugr, llvm_ctx);
+    }
+
+    #[rstest]
+    #[case("trunc_u", 6)]
+    #[case("trunc_s", 5)]
+    fn test_truncation(mut llvm_ctx: TestContext, #[case] op_name: &str, #[case] width: u8) -> () {
+        llvm_ctx.add_extensions(add_int_extensions);
+        llvm_ctx.add_extensions(add_float_extensions);
+        llvm_ctx.add_extensions(add_conversions_extension);
+        llvm_ctx.add_extensions(add_default_prelude_extensions);
+        let in_ty = FLOAT64_TYPE;
+        let out_ty = sum_with_error(INT_TYPES[width as usize].clone());
+        let hugr = test_conversion_op(op_name, in_ty, out_ty.into(), width);
+        check_emission!(op_name, hugr, llvm_ctx);
+    }
+}

--- a/src/custom/conversions.rs
+++ b/src/custom/conversions.rs
@@ -143,6 +143,8 @@ impl<'c, H: HugrView> ConversionsEmitter<'c, '_, H> {
             }?
             .as_basic_value_enum();
 
+            let placeholder = ctx.iw_context().struct_type(&[int_ty.as_basic_type_enum()], false).get_undef();
+            let result_row = ctx.builder().build_insert_value(placeholder, trunc_result, 0, "result_row")?;
             let trunc_err_hugr_val = Value::extension(ConstError::new(
                 2,
                 format!(
@@ -163,7 +165,7 @@ impl<'c, H: HugrView> ConversionsEmitter<'c, '_, H> {
             let val = ctx.builder().build_insert_value(val, e, 1, "error val")?;
             let val =
                 ctx.builder()
-                    .build_insert_value(val, trunc_result, 2, "conversion_result")?;
+                    .build_insert_value(val, result_row, 2, "conversion_result")?;
             let val = ctx.builder().build_insert_value(val, success, 0, "tag")?;
 
             Ok(vec![val.as_basic_value_enum()])

--- a/src/custom/conversions.rs
+++ b/src/custom/conversions.rs
@@ -128,7 +128,7 @@ impl<'c, H: HugrView> ConversionsEmitter<'c, '_, H> {
                 flt_int_max,
                 "conversion_valid",
             )?;
-            let success = ctx.builder().build_int_s_extend(
+            let success = ctx.builder().build_int_z_extend(
                 success,
                 ctx.iw_context().i32_type(),
                 "conversion_valid_i32",

--- a/src/custom/conversions.rs
+++ b/src/custom/conversions.rs
@@ -44,12 +44,7 @@ impl<'c, H: HugrView> ConversionsEmitter<'c, '_, H> {
             4 => (16, (i16::MIN as i64, i16::MAX as i64), u16::MAX as u64),
             5 => (32, (i32::MIN as i64, i32::MAX as i64), u32::MAX as u64),
             6 => (64, (i64::MIN, i64::MAX), u64::MAX),
-            m => {
-                return Err(anyhow!(
-                    "ConversionEmitter: unsupported log_width: {}",
-                    m
-                ))
-            }
+            m => return Err(anyhow!("ConversionEmitter: unsupported log_width: {}", m)),
         };
 
         let hugr_int_ty = INT_TYPES[log_width as usize].clone();
@@ -298,7 +293,11 @@ mod test {
     #[rstest]
     #[case("trunc_u", 6)]
     #[case("trunc_s", 5)]
-    fn test_truncation(mut llvm_ctx: TestContext, #[case] op_name: &str, #[case] log_width: u8) -> () {
+    fn test_truncation(
+        mut llvm_ctx: TestContext,
+        #[case] op_name: &str,
+        #[case] log_width: u8,
+    ) -> () {
         llvm_ctx.add_extensions(add_int_extensions);
         llvm_ctx.add_extensions(add_float_extensions);
         llvm_ctx.add_extensions(add_conversions_extension);
@@ -425,7 +424,7 @@ mod test {
     // is standard behaviour...
     #[rstest]
     #[case(18_446_744_073_709_550_000, 18_446_744_073_709_549_568)]
-    #[case(18_446_744_073_709_551_615,  9_223_372_036_854_775_808)] // 2 ^ 63
+    #[case(18_446_744_073_709_551_615, 9_223_372_036_854_775_808)] // 2 ^ 63
     fn approx_roundtrip(mut exec_ctx: TestContext, #[case] val: u64, #[case] expected: u64) {
         add_extensions(&mut exec_ctx);
         let hugr = roundtrip_hugr(val);

--- a/src/custom/conversions.rs
+++ b/src/custom/conversions.rs
@@ -91,7 +91,11 @@ impl<'c, H: HugrView> ConversionsEmitter<'c, '_, H> {
                     .get_declaration(ctx.get_current_module(), &[int_ty.as_basic_type_enum()])
                     .unwrap();
 
-                let const_false = ctx.iw_context().bool_type().const_zero().as_basic_value_enum();
+                let const_false = ctx
+                    .iw_context()
+                    .bool_type()
+                    .const_zero()
+                    .as_basic_value_enum();
                 let abs_call = ctx
                     .builder()
                     .build_call(abs, &[int_max.into(), const_false.into()], "max_int_pos")?
@@ -143,8 +147,13 @@ impl<'c, H: HugrView> ConversionsEmitter<'c, '_, H> {
             }?
             .as_basic_value_enum();
 
-            let placeholder = ctx.iw_context().struct_type(&[int_ty.as_basic_type_enum()], false).get_undef();
-            let result_row = ctx.builder().build_insert_value(placeholder, trunc_result, 0, "result_row")?;
+            let placeholder = ctx
+                .iw_context()
+                .struct_type(&[int_ty.as_basic_type_enum()], false)
+                .get_undef();
+            let result_row =
+                ctx.builder()
+                    .build_insert_value(placeholder, trunc_result, 0, "result_row")?;
             let trunc_err_hugr_val = Value::extension(ConstError::new(
                 2,
                 format!(
@@ -163,9 +172,9 @@ impl<'c, H: HugrView> ConversionsEmitter<'c, '_, H> {
                 .as_basic_value_enum()
                 .into_struct_value();
             let val = ctx.builder().build_insert_value(val, e, 1, "error val")?;
-            let val =
-                ctx.builder()
-                    .build_insert_value(val, result_row, 2, "conversion_result")?;
+            let val = ctx
+                .builder()
+                .build_insert_value(val, result_row, 2, "conversion_result")?;
             let val = ctx.builder().build_insert_value(val, success, 0, "tag")?;
 
             Ok(vec![val.as_basic_value_enum()])

--- a/src/custom/float.rs
+++ b/src/custom/float.rs
@@ -146,8 +146,9 @@ impl<'c, H: HugrView> EmitOp<'c, ExtensionOp, H> for FloatOpEmitter<'c, '_, H> {
                     .build_float_sub(lhs.into_float_value(), rhs.into_float_value(), "")?
                     .as_basic_value_enum()])
             }),
-            FloatOps::fneg => emit_custom_unary_op(self.0, args, |builder, v, _| {
-                Ok(vec![builder
+            FloatOps::fneg => emit_custom_unary_op(self.0, args, |ctx, v, _| {
+                Ok(vec![ctx
+                    .builder()
                     .build_float_neg(v.into_float_value(), "")?
                     .as_basic_value_enum()])
             }),

--- a/src/custom/float.rs
+++ b/src/custom/float.rs
@@ -107,16 +107,18 @@ fn emit_fcmp<'c, H: HugrView>(
     let true_val = emit_value(context, &Value::true_val())?;
     let false_val = emit_value(context, &Value::false_val())?;
 
-    emit_custom_binary_op(context, args, |builder, (lhs, rhs), _| {
+    emit_custom_binary_op(context, args, |ctx, (lhs, rhs), _| {
         // get result as an i1
-        let r = builder.build_float_compare(
+        let r = ctx.builder().build_float_compare(
             pred,
             lhs.into_float_value(),
             rhs.into_float_value(),
             "",
         )?;
         // convert to whatever BOOL_T is
-        Ok(vec![builder.build_select(r, true_val, false_val, "")?])
+        Ok(vec![ctx
+            .builder()
+            .build_select(r, true_val, false_val, "")?])
     })
 }
 
@@ -136,13 +138,15 @@ impl<'c, H: HugrView> EmitOp<'c, ExtensionOp, H> for FloatOpEmitter<'c, '_, H> {
             FloatOps::fgt => emit_fcmp(self.0, args, inkwell::FloatPredicate::OGT),
             FloatOps::fle => emit_fcmp(self.0, args, inkwell::FloatPredicate::OLE),
             FloatOps::fge => emit_fcmp(self.0, args, inkwell::FloatPredicate::OGE),
-            FloatOps::fadd => emit_custom_binary_op(self.0, args, |builder, (lhs, rhs), _| {
-                Ok(vec![builder
+            FloatOps::fadd => emit_custom_binary_op(self.0, args, |ctx, (lhs, rhs), _| {
+                Ok(vec![ctx
+                    .builder()
                     .build_float_add(lhs.into_float_value(), rhs.into_float_value(), "")?
                     .as_basic_value_enum()])
             }),
-            FloatOps::fsub => emit_custom_binary_op(self.0, args, |builder, (lhs, rhs), _| {
-                Ok(vec![builder
+            FloatOps::fsub => emit_custom_binary_op(self.0, args, |ctx, (lhs, rhs), _| {
+                Ok(vec![ctx
+                    .builder()
                     .build_float_sub(lhs.into_float_value(), rhs.into_float_value(), "")?
                     .as_basic_value_enum()])
             }),
@@ -152,13 +156,15 @@ impl<'c, H: HugrView> EmitOp<'c, ExtensionOp, H> for FloatOpEmitter<'c, '_, H> {
                     .build_float_neg(v.into_float_value(), "")?
                     .as_basic_value_enum()])
             }),
-            FloatOps::fmul => emit_custom_binary_op(self.0, args, |builder, (lhs, rhs), _| {
-                Ok(vec![builder
+            FloatOps::fmul => emit_custom_binary_op(self.0, args, |ctx, (lhs, rhs), _| {
+                Ok(vec![ctx
+                    .builder()
                     .build_float_mul(lhs.into_float_value(), rhs.into_float_value(), "")?
                     .as_basic_value_enum()])
             }),
-            FloatOps::fdiv => emit_custom_binary_op(self.0, args, |builder, (lhs, rhs), _| {
-                Ok(vec![builder
+            FloatOps::fdiv => emit_custom_binary_op(self.0, args, |ctx, (lhs, rhs), _| {
+                Ok(vec![ctx
+                    .builder()
                     .build_float_div(lhs.into_float_value(), rhs.into_float_value(), "")?
                     .as_basic_value_enum()])
             }),

--- a/src/custom/int.rs
+++ b/src/custom/int.rs
@@ -35,11 +35,18 @@ fn emit_icmp<'c, H: HugrView>(
     let true_val = emit_value(context, &Value::true_val())?;
     let false_val = emit_value(context, &Value::false_val())?;
 
-    emit_custom_binary_op(context, args, |builder, (lhs, rhs), _| {
+    emit_custom_binary_op(context, args, |ctx, (lhs, rhs), _| {
         // get result as an i1
-        let r = builder.build_int_compare(pred, lhs.into_int_value(), rhs.into_int_value(), "")?;
+        let r = ctx.builder().build_int_compare(
+            pred,
+            lhs.into_int_value(),
+            rhs.into_int_value(),
+            "",
+        )?;
         // convert to whatever BOOL_T is
-        Ok(vec![builder.build_select(r, true_val, false_val, "")?])
+        Ok(vec![ctx
+            .builder()
+            .build_select(r, true_val, false_val, "")?])
     })
 }
 
@@ -50,33 +57,39 @@ impl<'c, H: HugrView> EmitOp<'c, ExtensionOp, H> for IntOpEmitter<'c, '_, H> {
             args.node().as_ref()
         ))?;
         match iot.def {
-            IntOpDef::iadd => emit_custom_binary_op(self.0, args, |builder, (lhs, rhs), _| {
-                Ok(vec![builder
+            IntOpDef::iadd => emit_custom_binary_op(self.0, args, |ctx, (lhs, rhs), _| {
+                Ok(vec![ctx
+                    .builder()
                     .build_int_add(lhs.into_int_value(), rhs.into_int_value(), "")?
                     .as_basic_value_enum()])
             }),
-            IntOpDef::imul => emit_custom_binary_op(self.0, args, |builder, (lhs, rhs), _| {
-                Ok(vec![builder
+            IntOpDef::imul => emit_custom_binary_op(self.0, args, |ctx, (lhs, rhs), _| {
+                Ok(vec![ctx
+                    .builder()
                     .build_int_mul(lhs.into_int_value(), rhs.into_int_value(), "")?
                     .as_basic_value_enum()])
             }),
-            IntOpDef::isub => emit_custom_binary_op(self.0, args, |builder, (lhs, rhs), _| {
-                Ok(vec![builder
+            IntOpDef::isub => emit_custom_binary_op(self.0, args, |ctx, (lhs, rhs), _| {
+                Ok(vec![ctx
+                    .builder()
                     .build_int_sub(lhs.into_int_value(), rhs.into_int_value(), "")?
                     .as_basic_value_enum()])
             }),
-            IntOpDef::idiv_s => emit_custom_binary_op(self.0, args, |builder, (lhs, rhs), _| {
-                Ok(vec![builder
+            IntOpDef::idiv_s => emit_custom_binary_op(self.0, args, |ctx, (lhs, rhs), _| {
+                Ok(vec![ctx
+                    .builder()
                     .build_int_signed_div(lhs.into_int_value(), rhs.into_int_value(), "")?
                     .as_basic_value_enum()])
             }),
-            IntOpDef::idiv_u => emit_custom_binary_op(self.0, args, |builder, (lhs, rhs), _| {
-                Ok(vec![builder
+            IntOpDef::idiv_u => emit_custom_binary_op(self.0, args, |ctx, (lhs, rhs), _| {
+                Ok(vec![ctx
+                    .builder()
                     .build_int_unsigned_div(lhs.into_int_value(), rhs.into_int_value(), "")?
                     .as_basic_value_enum()])
             }),
-            IntOpDef::imod_s => emit_custom_binary_op(self.0, args, |builder, (lhs, rhs), _| {
-                Ok(vec![builder
+            IntOpDef::imod_s => emit_custom_binary_op(self.0, args, |ctx, (lhs, rhs), _| {
+                Ok(vec![ctx
+                    .builder()
                     .build_int_signed_rem(lhs.into_int_value(), rhs.into_int_value(), "")?
                     .as_basic_value_enum()])
             }),

--- a/src/custom/int.rs
+++ b/src/custom/int.rs
@@ -46,7 +46,7 @@ fn emit_icmp<'c, H: HugrView>(
 impl<'c, H: HugrView> EmitOp<'c, ExtensionOp, H> for IntOpEmitter<'c, '_, H> {
     fn emit(&mut self, args: EmitOpArgs<'c, ExtensionOp, H>) -> Result<()> {
         let iot = ConcreteIntOp::from_optype(&args.node().generalise()).ok_or(anyhow!(
-            "IntOpEmitter from_optype_failed: {:?}",
+            "IntOpEmitter from_optype failed: {:?}",
             args.node().as_ref()
         ))?;
         match iot.def {
@@ -80,8 +80,9 @@ impl<'c, H: HugrView> EmitOp<'c, ExtensionOp, H> for IntOpEmitter<'c, '_, H> {
                     .build_int_signed_rem(lhs.into_int_value(), rhs.into_int_value(), "")?
                     .as_basic_value_enum()])
             }),
-            IntOpDef::ineg => emit_custom_unary_op(self.0, args, |builder, arg, _| {
-                Ok(vec![builder
+            IntOpDef::ineg => emit_custom_unary_op(self.0, args, |ctx, arg, _| {
+                Ok(vec![ctx
+                    .builder()
                     .build_int_neg(arg.into_int_value(), "")?
                     .as_basic_value_enum()])
             }),

--- a/src/custom/snapshots/hugr_llvm__custom__conversions__test__convert_s@llvm14.snap
+++ b/src/custom/snapshots/hugr_llvm__custom__conversions__test__convert_s@llvm14.snap
@@ -1,0 +1,15 @@
+---
+source: src/custom/conversions.rs
+expression: module.to_string()
+---
+; ModuleID = 'test_context'
+source_filename = "test_context"
+
+define double @_hl.main.1(i32 %0) {
+alloca_block:
+  br label %entry_block
+
+entry_block:                                      ; preds = %alloca_block
+  %1 = sitofp i32 %0 to double
+  ret double %1
+}

--- a/src/custom/snapshots/hugr_llvm__custom__conversions__test__convert_s@pre-mem2reg@llvm14.snap
+++ b/src/custom/snapshots/hugr_llvm__custom__conversions__test__convert_s@pre-mem2reg@llvm14.snap
@@ -1,0 +1,24 @@
+---
+source: src/custom/conversions.rs
+expression: module.to_string()
+---
+; ModuleID = 'test_context'
+source_filename = "test_context"
+
+define double @_hl.main.1(i32 %0) {
+alloca_block:
+  %"0" = alloca double, align 8
+  %"2_0" = alloca i32, align 4
+  %"4_0" = alloca double, align 8
+  br label %entry_block
+
+entry_block:                                      ; preds = %alloca_block
+  store i32 %0, i32* %"2_0", align 4
+  %"2_01" = load i32, i32* %"2_0", align 4
+  %1 = sitofp i32 %"2_01" to double
+  store double %1, double* %"4_0", align 8
+  %"4_02" = load double, double* %"4_0", align 8
+  store double %"4_02", double* %"0", align 8
+  %"03" = load double, double* %"0", align 8
+  ret double %"03"
+}

--- a/src/custom/snapshots/hugr_llvm__custom__conversions__test__convert_u@llvm14.snap
+++ b/src/custom/snapshots/hugr_llvm__custom__conversions__test__convert_u@llvm14.snap
@@ -1,0 +1,15 @@
+---
+source: src/custom/conversions.rs
+expression: module.to_string()
+---
+; ModuleID = 'test_context'
+source_filename = "test_context"
+
+define double @_hl.main.1(i16 %0) {
+alloca_block:
+  br label %entry_block
+
+entry_block:                                      ; preds = %alloca_block
+  %1 = uitofp i16 %0 to double
+  ret double %1
+}

--- a/src/custom/snapshots/hugr_llvm__custom__conversions__test__convert_u@pre-mem2reg@llvm14.snap
+++ b/src/custom/snapshots/hugr_llvm__custom__conversions__test__convert_u@pre-mem2reg@llvm14.snap
@@ -1,0 +1,24 @@
+---
+source: src/custom/conversions.rs
+expression: module.to_string()
+---
+; ModuleID = 'test_context'
+source_filename = "test_context"
+
+define double @_hl.main.1(i16 %0) {
+alloca_block:
+  %"0" = alloca double, align 8
+  %"2_0" = alloca i16, align 2
+  %"4_0" = alloca double, align 8
+  br label %entry_block
+
+entry_block:                                      ; preds = %alloca_block
+  store i16 %0, i16* %"2_0", align 2
+  %"2_01" = load i16, i16* %"2_0", align 2
+  %1 = uitofp i16 %"2_01" to double
+  store double %1, double* %"4_0", align 8
+  %"4_02" = load double, double* %"4_0", align 8
+  store double %"4_02", double* %"0", align 8
+  %"03" = load double, double* %"0", align 8
+  ret double %"03"
+}

--- a/src/custom/snapshots/hugr_llvm__custom__conversions__test__trunc_s@llvm14.snap
+++ b/src/custom/snapshots/hugr_llvm__custom__conversions__test__trunc_s@llvm14.snap
@@ -5,13 +5,29 @@ expression: module.to_string()
 ; ModuleID = 'test_context'
 source_filename = "test_context"
 
+@0 = private unnamed_addr constant [58 x i8] c"Float value too big to convert to int of given width (32)\00", align 1
+
 define { i32, { { i32, i8* } }, { i32 } } @_hl.main.1(double %0) {
 alloca_block:
   br label %entry_block
 
 entry_block:                                      ; preds = %alloca_block
+  %max_int_pos = call i32 @llvm.abs.i32(i32 2147483647, i1 false)
+  %max_flt_pos = sitofp i32 %max_int_pos to double
+  %flt_pos = call double @llvm.fabs.f64(double %0)
+  %conversion_valid = fcmp ole double %flt_pos, %max_flt_pos
+  %conversion_valid_i32 = sext i1 %conversion_valid to i32
   %1 = fptosi double %0 to i32
-  %2 = insertvalue { i32 } undef, i32 %1, 0
-  %3 = insertvalue { i32, { { i32, i8* } }, { i32 } } { i32 1, { { i32, i8* } } poison, { i32 } poison }, { i32 } %2, 2
-  ret { i32, { { i32, i8* } }, { i32 } } %3
+  %result_row = insertvalue { i32 } undef, i32 %1, 0
+  %conversion_result = insertvalue { i32, { { i32, i8* } }, { i32 } } { i32 poison, { i32, i8* } { i32 2, i8* getelementptr inbounds ([58 x i8], [58 x i8]* @0, i32 0, i32 0) }, { i32 } poison }, { i32 } %result_row, 2
+  %tag = insertvalue { i32, { { i32, i8* } }, { i32 } } %conversion_result, i32 %conversion_valid_i32, 0
+  ret { i32, { { i32, i8* } }, { i32 } } %tag
 }
+
+; Function Attrs: nofree nosync nounwind readnone speculatable willreturn
+declare double @llvm.fabs.f64(double) #0
+
+; Function Attrs: nofree nosync nounwind readnone speculatable willreturn
+declare i32 @llvm.abs.i32(i32, i1 immarg) #0
+
+attributes #0 = { nofree nosync nounwind readnone speculatable willreturn }

--- a/src/custom/snapshots/hugr_llvm__custom__conversions__test__trunc_s@llvm14.snap
+++ b/src/custom/snapshots/hugr_llvm__custom__conversions__test__trunc_s@llvm14.snap
@@ -12,10 +12,8 @@ alloca_block:
   br label %entry_block
 
 entry_block:                                      ; preds = %alloca_block
-  %max_int_pos = call i32 @llvm.abs.i32(i32 2147483647, i1 false)
-  %max_flt_pos = sitofp i32 %max_int_pos to double
   %flt_pos = call double @llvm.fabs.f64(double %0)
-  %conversion_valid = fcmp ole double %flt_pos, %max_flt_pos
+  %conversion_valid = fcmp ole double %flt_pos, 0x41DFFFFFFFC00000
   %conversion_valid_i32 = zext i1 %conversion_valid to i32
   %1 = fptosi double %0 to i32
   %result_row = insertvalue { i32 } undef, i32 %1, 0
@@ -26,8 +24,5 @@ entry_block:                                      ; preds = %alloca_block
 
 ; Function Attrs: nofree nosync nounwind readnone speculatable willreturn
 declare double @llvm.fabs.f64(double) #0
-
-; Function Attrs: nofree nosync nounwind readnone speculatable willreturn
-declare i32 @llvm.abs.i32(i32, i1 immarg) #0
 
 attributes #0 = { nofree nosync nounwind readnone speculatable willreturn }

--- a/src/custom/snapshots/hugr_llvm__custom__conversions__test__trunc_s@llvm14.snap
+++ b/src/custom/snapshots/hugr_llvm__custom__conversions__test__trunc_s@llvm14.snap
@@ -14,7 +14,6 @@ alloca_block:
 entry_block:                                      ; preds = %alloca_block
   %flt_pos = call double @llvm.fabs.f64(double %0)
   %conversion_valid = fcmp ole double %flt_pos, 0x41DFFFFFFFC00000
-  %conversion_valid_i32 = zext i1 %conversion_valid to i32
   %trunc_result = fptosi double %0 to i32
   %1 = insertvalue { i32 } undef, i32 %trunc_result, 0
   %2 = insertvalue { i32, { { i32, i8* } }, { i32 } } { i32 1, { { i32, i8* } } poison, { i32 } poison }, { i32 } %1, 2

--- a/src/custom/snapshots/hugr_llvm__custom__conversions__test__trunc_s@llvm14.snap
+++ b/src/custom/snapshots/hugr_llvm__custom__conversions__test__trunc_s@llvm14.snap
@@ -1,6 +1,6 @@
 ---
 source: src/custom/conversions.rs
-expression: module.to_string()
+expression: mod_str
 ---
 ; ModuleID = 'test_context'
 source_filename = "test_context"
@@ -16,10 +16,10 @@ entry_block:                                      ; preds = %alloca_block
   %max_flt_pos = sitofp i32 %max_int_pos to double
   %flt_pos = call double @llvm.fabs.f64(double %0)
   %conversion_valid = fcmp ole double %flt_pos, %max_flt_pos
-  %conversion_valid_i32 = sext i1 %conversion_valid to i32
+  %conversion_valid_i32 = zext i1 %conversion_valid to i32
   %1 = fptosi double %0 to i32
   %result_row = insertvalue { i32 } undef, i32 %1, 0
-  %conversion_result = insertvalue { i32, { { i32, i8* } }, { i32 } } { i32 poison, { i32, i8* } { i32 2, i8* getelementptr inbounds ([58 x i8], [58 x i8]* @0, i32 0, i32 0) }, { i32 } poison }, { i32 } %result_row, 2
+  %conversion_result = insertvalue { i32, { { i32, i8* } }, { i32 } } { i32 undef, { i32, i8* } { i32 2, i8* getelementptr inbounds ([58 x i8], [58 x i8]* @0, i32 0, i32 0) }, { i32 } undef }, { i32 } %result_row, 2
   %tag = insertvalue { i32, { { i32, i8* } }, { i32 } } %conversion_result, i32 %conversion_valid_i32, 0
   ret { i32, { { i32, i8* } }, { i32 } } %tag
 }

--- a/src/custom/snapshots/hugr_llvm__custom__conversions__test__trunc_s@llvm14.snap
+++ b/src/custom/snapshots/hugr_llvm__custom__conversions__test__trunc_s@llvm14.snap
@@ -1,0 +1,17 @@
+---
+source: src/custom/conversions.rs
+expression: module.to_string()
+---
+; ModuleID = 'test_context'
+source_filename = "test_context"
+
+define { i32, { { i32, i8* } }, { i32 } } @_hl.main.1(double %0) {
+alloca_block:
+  br label %entry_block
+
+entry_block:                                      ; preds = %alloca_block
+  %1 = fptosi double %0 to i32
+  %2 = insertvalue { i32 } undef, i32 %1, 0
+  %3 = insertvalue { i32, { { i32, i8* } }, { i32 } } { i32 1, { { i32, i8* } } poison, { i32 } poison }, { i32 } %2, 2
+  ret { i32, { { i32, i8* } }, { i32 } } %3
+}

--- a/src/custom/snapshots/hugr_llvm__custom__conversions__test__trunc_s@llvm14.snap
+++ b/src/custom/snapshots/hugr_llvm__custom__conversions__test__trunc_s@llvm14.snap
@@ -15,11 +15,11 @@ entry_block:                                      ; preds = %alloca_block
   %flt_pos = call double @llvm.fabs.f64(double %0)
   %conversion_valid = fcmp ole double %flt_pos, 0x41DFFFFFFFC00000
   %conversion_valid_i32 = zext i1 %conversion_valid to i32
-  %1 = fptosi double %0 to i32
-  %result_row = insertvalue { i32 } undef, i32 %1, 0
-  %conversion_result = insertvalue { i32, { { i32, i8* } }, { i32 } } { i32 undef, { i32, i8* } { i32 2, i8* getelementptr inbounds ([58 x i8], [58 x i8]* @0, i32 0, i32 0) }, { i32 } undef }, { i32 } %result_row, 2
-  %tag = insertvalue { i32, { { i32, i8* } }, { i32 } } %conversion_result, i32 %conversion_valid_i32, 0
-  ret { i32, { { i32, i8* } }, { i32 } } %tag
+  %trunc_result = fptosi double %0 to i32
+  %1 = insertvalue { i32 } undef, i32 %trunc_result, 0
+  %2 = insertvalue { i32, { { i32, i8* } }, { i32 } } { i32 1, { { i32, i8* } } poison, { i32 } poison }, { i32 } %1, 2
+  %3 = select i1 %conversion_valid, { i32, { { i32, i8* } }, { i32 } } %2, { i32, { { i32, i8* } }, { i32 } } { i32 0, { { i32, i8* } } { { i32, i8* } { i32 2, i8* getelementptr inbounds ([58 x i8], [58 x i8]* @0, i32 0, i32 0) } }, { i32 } poison }
+  ret { i32, { { i32, i8* } }, { i32 } } %3
 }
 
 ; Function Attrs: nofree nosync nounwind readnone speculatable willreturn

--- a/src/custom/snapshots/hugr_llvm__custom__conversions__test__trunc_s@llvm14.snap
+++ b/src/custom/snapshots/hugr_llvm__custom__conversions__test__trunc_s@llvm14.snap
@@ -12,16 +12,12 @@ alloca_block:
   br label %entry_block
 
 entry_block:                                      ; preds = %alloca_block
-  %flt_pos = call double @llvm.fabs.f64(double %0)
-  %conversion_valid = fcmp ole double %flt_pos, 0x41DFFFFFFFC00000
+  %within_upper_bound = fcmp ole double %0, 0x41DFFFFFFFC00000
+  %within_lower_bound = fcmp ole double 0xC1E0000000000000, %0
+  %success = and i1 %within_upper_bound, %within_lower_bound
   %trunc_result = fptosi double %0 to i32
   %1 = insertvalue { i32 } undef, i32 %trunc_result, 0
   %2 = insertvalue { i32, { { i32, i8* } }, { i32 } } { i32 1, { { i32, i8* } } poison, { i32 } poison }, { i32 } %1, 2
-  %3 = select i1 %conversion_valid, { i32, { { i32, i8* } }, { i32 } } %2, { i32, { { i32, i8* } }, { i32 } } { i32 0, { { i32, i8* } } { { i32, i8* } { i32 2, i8* getelementptr inbounds ([58 x i8], [58 x i8]* @0, i32 0, i32 0) } }, { i32 } poison }
+  %3 = select i1 %success, { i32, { { i32, i8* } }, { i32 } } %2, { i32, { { i32, i8* } }, { i32 } } { i32 0, { { i32, i8* } } { { i32, i8* } { i32 2, i8* getelementptr inbounds ([58 x i8], [58 x i8]* @0, i32 0, i32 0) } }, { i32 } poison }
   ret { i32, { { i32, i8* } }, { i32 } } %3
 }
-
-; Function Attrs: nofree nosync nounwind readnone speculatable willreturn
-declare double @llvm.fabs.f64(double) #0
-
-attributes #0 = { nofree nosync nounwind readnone speculatable willreturn }

--- a/src/custom/snapshots/hugr_llvm__custom__conversions__test__trunc_s@pre-mem2reg@llvm14.snap
+++ b/src/custom/snapshots/hugr_llvm__custom__conversions__test__trunc_s@pre-mem2reg@llvm14.snap
@@ -17,13 +17,14 @@ alloca_block:
 entry_block:                                      ; preds = %alloca_block
   store double %0, double* %"2_0", align 8
   %"2_01" = load double, double* %"2_0", align 8
-  %max_int_pos = call i32 @llvm.abs.i32(i32 2147483647)
+  %max_int_pos = call i32 @llvm.abs.i32(i32 2147483647, i1 false)
   %max_flt_pos = sitofp i32 %max_int_pos to double
   %flt_pos = call double @llvm.fabs.f64(double %"2_01")
   %conversion_valid = fcmp ole double %flt_pos, %max_flt_pos
   %conversion_valid_i32 = sext i1 %conversion_valid to i32
   %1 = fptosi double %"2_01" to i32
-  %conversion_result = insertvalue { i32, { { i32, i8* } }, { i32 } } { i32 poison, { i32, i8* } { i32 2, i8* getelementptr inbounds ([58 x i8], [58 x i8]* @0, i32 0, i32 0) }, { i32 } poison }, i32 %1, 2
+  %result_row = insertvalue { i32 } undef, i32 %1, 0
+  %conversion_result = insertvalue { i32, { { i32, i8* } }, { i32 } } { i32 poison, { i32, i8* } { i32 2, i8* getelementptr inbounds ([58 x i8], [58 x i8]* @0, i32 0, i32 0) }, { i32 } poison }, { i32 } %result_row, 2
   %tag = insertvalue { i32, { { i32, i8* } }, { i32 } } %conversion_result, i32 %conversion_valid_i32, 0
   store { i32, { { i32, i8* } }, { i32 } } %tag, { i32, { { i32, i8* } }, { i32 } }* %"4_0", align 8
   %"4_02" = load { i32, { { i32, i8* } }, { i32 } }, { i32, { { i32, i8* } }, { i32 } }* %"4_0", align 8

--- a/src/custom/snapshots/hugr_llvm__custom__conversions__test__trunc_s@pre-mem2reg@llvm14.snap
+++ b/src/custom/snapshots/hugr_llvm__custom__conversions__test__trunc_s@pre-mem2reg@llvm14.snap
@@ -20,11 +20,11 @@ entry_block:                                      ; preds = %alloca_block
   %flt_pos = call double @llvm.fabs.f64(double %"2_01")
   %conversion_valid = fcmp ole double %flt_pos, 0x41DFFFFFFFC00000
   %conversion_valid_i32 = zext i1 %conversion_valid to i32
-  %1 = fptosi double %"2_01" to i32
-  %result_row = insertvalue { i32 } undef, i32 %1, 0
-  %conversion_result = insertvalue { i32, { { i32, i8* } }, { i32 } } { i32 undef, { i32, i8* } { i32 2, i8* getelementptr inbounds ([58 x i8], [58 x i8]* @0, i32 0, i32 0) }, { i32 } undef }, { i32 } %result_row, 2
-  %tag = insertvalue { i32, { { i32, i8* } }, { i32 } } %conversion_result, i32 %conversion_valid_i32, 0
-  store { i32, { { i32, i8* } }, { i32 } } %tag, { i32, { { i32, i8* } }, { i32 } }* %"4_0", align 8
+  %trunc_result = fptosi double %"2_01" to i32
+  %1 = insertvalue { i32 } undef, i32 %trunc_result, 0
+  %2 = insertvalue { i32, { { i32, i8* } }, { i32 } } { i32 1, { { i32, i8* } } poison, { i32 } poison }, { i32 } %1, 2
+  %3 = select i1 %conversion_valid, { i32, { { i32, i8* } }, { i32 } } %2, { i32, { { i32, i8* } }, { i32 } } { i32 0, { { i32, i8* } } { { i32, i8* } { i32 2, i8* getelementptr inbounds ([58 x i8], [58 x i8]* @0, i32 0, i32 0) } }, { i32 } poison }
+  store { i32, { { i32, i8* } }, { i32 } } %3, { i32, { { i32, i8* } }, { i32 } }* %"4_0", align 8
   %"4_02" = load { i32, { { i32, i8* } }, { i32 } }, { i32, { { i32, i8* } }, { i32 } }* %"4_0", align 8
   store { i32, { { i32, i8* } }, { i32 } } %"4_02", { i32, { { i32, i8* } }, { i32 } }* %"0", align 8
   %"03" = load { i32, { { i32, i8* } }, { i32 } }, { i32, { { i32, i8* } }, { i32 } }* %"0", align 8

--- a/src/custom/snapshots/hugr_llvm__custom__conversions__test__trunc_s@pre-mem2reg@llvm14.snap
+++ b/src/custom/snapshots/hugr_llvm__custom__conversions__test__trunc_s@pre-mem2reg@llvm14.snap
@@ -19,7 +19,6 @@ entry_block:                                      ; preds = %alloca_block
   %"2_01" = load double, double* %"2_0", align 8
   %flt_pos = call double @llvm.fabs.f64(double %"2_01")
   %conversion_valid = fcmp ole double %flt_pos, 0x41DFFFFFFFC00000
-  %conversion_valid_i32 = zext i1 %conversion_valid to i32
   %trunc_result = fptosi double %"2_01" to i32
   %1 = insertvalue { i32 } undef, i32 %trunc_result, 0
   %2 = insertvalue { i32, { { i32, i8* } }, { i32 } } { i32 1, { { i32, i8* } } poison, { i32 } poison }, { i32 } %1, 2

--- a/src/custom/snapshots/hugr_llvm__custom__conversions__test__trunc_s@pre-mem2reg@llvm14.snap
+++ b/src/custom/snapshots/hugr_llvm__custom__conversions__test__trunc_s@pre-mem2reg@llvm14.snap
@@ -17,10 +17,8 @@ alloca_block:
 entry_block:                                      ; preds = %alloca_block
   store double %0, double* %"2_0", align 8
   %"2_01" = load double, double* %"2_0", align 8
-  %max_int_pos = call i32 @llvm.abs.i32(i32 2147483647, i1 false)
-  %max_flt_pos = sitofp i32 %max_int_pos to double
   %flt_pos = call double @llvm.fabs.f64(double %"2_01")
-  %conversion_valid = fcmp ole double %flt_pos, %max_flt_pos
+  %conversion_valid = fcmp ole double %flt_pos, 0x41DFFFFFFFC00000
   %conversion_valid_i32 = zext i1 %conversion_valid to i32
   %1 = fptosi double %"2_01" to i32
   %result_row = insertvalue { i32 } undef, i32 %1, 0
@@ -35,8 +33,5 @@ entry_block:                                      ; preds = %alloca_block
 
 ; Function Attrs: nofree nosync nounwind readnone speculatable willreturn
 declare double @llvm.fabs.f64(double) #0
-
-; Function Attrs: nofree nosync nounwind readnone speculatable willreturn
-declare i32 @llvm.abs.i32(i32, i1 immarg) #0
 
 attributes #0 = { nofree nosync nounwind readnone speculatable willreturn }

--- a/src/custom/snapshots/hugr_llvm__custom__conversions__test__trunc_s@pre-mem2reg@llvm14.snap
+++ b/src/custom/snapshots/hugr_llvm__custom__conversions__test__trunc_s@pre-mem2reg@llvm14.snap
@@ -1,0 +1,26 @@
+---
+source: src/custom/conversions.rs
+expression: module.to_string()
+---
+; ModuleID = 'test_context'
+source_filename = "test_context"
+
+define { i32, { { i32, i8* } }, { i32 } } @_hl.main.1(double %0) {
+alloca_block:
+  %"0" = alloca { i32, { { i32, i8* } }, { i32 } }, align 8
+  %"2_0" = alloca double, align 8
+  %"4_0" = alloca { i32, { { i32, i8* } }, { i32 } }, align 8
+  br label %entry_block
+
+entry_block:                                      ; preds = %alloca_block
+  store double %0, double* %"2_0", align 8
+  %"2_01" = load double, double* %"2_0", align 8
+  %1 = fptosi double %"2_01" to i32
+  %2 = insertvalue { i32 } undef, i32 %1, 0
+  %3 = insertvalue { i32, { { i32, i8* } }, { i32 } } { i32 1, { { i32, i8* } } poison, { i32 } poison }, { i32 } %2, 2
+  store { i32, { { i32, i8* } }, { i32 } } %3, { i32, { { i32, i8* } }, { i32 } }* %"4_0", align 8
+  %"4_02" = load { i32, { { i32, i8* } }, { i32 } }, { i32, { { i32, i8* } }, { i32 } }* %"4_0", align 8
+  store { i32, { { i32, i8* } }, { i32 } } %"4_02", { i32, { { i32, i8* } }, { i32 } }* %"0", align 8
+  %"03" = load { i32, { { i32, i8* } }, { i32 } }, { i32, { { i32, i8* } }, { i32 } }* %"0", align 8
+  ret { i32, { { i32, i8* } }, { i32 } } %"03"
+}

--- a/src/custom/snapshots/hugr_llvm__custom__conversions__test__trunc_s@pre-mem2reg@llvm14.snap
+++ b/src/custom/snapshots/hugr_llvm__custom__conversions__test__trunc_s@pre-mem2reg@llvm14.snap
@@ -17,20 +17,16 @@ alloca_block:
 entry_block:                                      ; preds = %alloca_block
   store double %0, double* %"2_0", align 8
   %"2_01" = load double, double* %"2_0", align 8
-  %flt_pos = call double @llvm.fabs.f64(double %"2_01")
-  %conversion_valid = fcmp ole double %flt_pos, 0x41DFFFFFFFC00000
+  %within_upper_bound = fcmp ole double %"2_01", 0x41DFFFFFFFC00000
+  %within_lower_bound = fcmp ole double 0xC1E0000000000000, %"2_01"
+  %success = and i1 %within_upper_bound, %within_lower_bound
   %trunc_result = fptosi double %"2_01" to i32
   %1 = insertvalue { i32 } undef, i32 %trunc_result, 0
   %2 = insertvalue { i32, { { i32, i8* } }, { i32 } } { i32 1, { { i32, i8* } } poison, { i32 } poison }, { i32 } %1, 2
-  %3 = select i1 %conversion_valid, { i32, { { i32, i8* } }, { i32 } } %2, { i32, { { i32, i8* } }, { i32 } } { i32 0, { { i32, i8* } } { { i32, i8* } { i32 2, i8* getelementptr inbounds ([58 x i8], [58 x i8]* @0, i32 0, i32 0) } }, { i32 } poison }
+  %3 = select i1 %success, { i32, { { i32, i8* } }, { i32 } } %2, { i32, { { i32, i8* } }, { i32 } } { i32 0, { { i32, i8* } } { { i32, i8* } { i32 2, i8* getelementptr inbounds ([58 x i8], [58 x i8]* @0, i32 0, i32 0) } }, { i32 } poison }
   store { i32, { { i32, i8* } }, { i32 } } %3, { i32, { { i32, i8* } }, { i32 } }* %"4_0", align 8
   %"4_02" = load { i32, { { i32, i8* } }, { i32 } }, { i32, { { i32, i8* } }, { i32 } }* %"4_0", align 8
   store { i32, { { i32, i8* } }, { i32 } } %"4_02", { i32, { { i32, i8* } }, { i32 } }* %"0", align 8
   %"03" = load { i32, { { i32, i8* } }, { i32 } }, { i32, { { i32, i8* } }, { i32 } }* %"0", align 8
   ret { i32, { { i32, i8* } }, { i32 } } %"03"
 }
-
-; Function Attrs: nofree nosync nounwind readnone speculatable willreturn
-declare double @llvm.fabs.f64(double) #0
-
-attributes #0 = { nofree nosync nounwind readnone speculatable willreturn }

--- a/src/custom/snapshots/hugr_llvm__custom__conversions__test__trunc_s@pre-mem2reg@llvm14.snap
+++ b/src/custom/snapshots/hugr_llvm__custom__conversions__test__trunc_s@pre-mem2reg@llvm14.snap
@@ -5,6 +5,8 @@ expression: module.to_string()
 ; ModuleID = 'test_context'
 source_filename = "test_context"
 
+@0 = private unnamed_addr constant [58 x i8] c"Float value too big to convert to int of given width (32)\00", align 1
+
 define { i32, { { i32, i8* } }, { i32 } } @_hl.main.1(double %0) {
 alloca_block:
   %"0" = alloca { i32, { { i32, i8* } }, { i32 } }, align 8
@@ -15,12 +17,25 @@ alloca_block:
 entry_block:                                      ; preds = %alloca_block
   store double %0, double* %"2_0", align 8
   %"2_01" = load double, double* %"2_0", align 8
+  %max_int_pos = call i32 @llvm.abs.i32(i32 2147483647)
+  %max_flt_pos = sitofp i32 %max_int_pos to double
+  %flt_pos = call double @llvm.fabs.f64(double %"2_01")
+  %conversion_valid = fcmp ole double %flt_pos, %max_flt_pos
+  %conversion_valid_i32 = sext i1 %conversion_valid to i32
   %1 = fptosi double %"2_01" to i32
-  %2 = insertvalue { i32 } undef, i32 %1, 0
-  %3 = insertvalue { i32, { { i32, i8* } }, { i32 } } { i32 1, { { i32, i8* } } poison, { i32 } poison }, { i32 } %2, 2
-  store { i32, { { i32, i8* } }, { i32 } } %3, { i32, { { i32, i8* } }, { i32 } }* %"4_0", align 8
+  %conversion_result = insertvalue { i32, { { i32, i8* } }, { i32 } } { i32 poison, { i32, i8* } { i32 2, i8* getelementptr inbounds ([58 x i8], [58 x i8]* @0, i32 0, i32 0) }, { i32 } poison }, i32 %1, 2
+  %tag = insertvalue { i32, { { i32, i8* } }, { i32 } } %conversion_result, i32 %conversion_valid_i32, 0
+  store { i32, { { i32, i8* } }, { i32 } } %tag, { i32, { { i32, i8* } }, { i32 } }* %"4_0", align 8
   %"4_02" = load { i32, { { i32, i8* } }, { i32 } }, { i32, { { i32, i8* } }, { i32 } }* %"4_0", align 8
   store { i32, { { i32, i8* } }, { i32 } } %"4_02", { i32, { { i32, i8* } }, { i32 } }* %"0", align 8
   %"03" = load { i32, { { i32, i8* } }, { i32 } }, { i32, { { i32, i8* } }, { i32 } }* %"0", align 8
   ret { i32, { { i32, i8* } }, { i32 } } %"03"
 }
+
+; Function Attrs: nofree nosync nounwind readnone speculatable willreturn
+declare double @llvm.fabs.f64(double) #0
+
+; Function Attrs: nofree nosync nounwind readnone speculatable willreturn
+declare i32 @llvm.abs.i32(i32, i1 immarg) #0
+
+attributes #0 = { nofree nosync nounwind readnone speculatable willreturn }

--- a/src/custom/snapshots/hugr_llvm__custom__conversions__test__trunc_s@pre-mem2reg@llvm14.snap
+++ b/src/custom/snapshots/hugr_llvm__custom__conversions__test__trunc_s@pre-mem2reg@llvm14.snap
@@ -1,6 +1,6 @@
 ---
 source: src/custom/conversions.rs
-expression: module.to_string()
+expression: mod_str
 ---
 ; ModuleID = 'test_context'
 source_filename = "test_context"
@@ -21,10 +21,10 @@ entry_block:                                      ; preds = %alloca_block
   %max_flt_pos = sitofp i32 %max_int_pos to double
   %flt_pos = call double @llvm.fabs.f64(double %"2_01")
   %conversion_valid = fcmp ole double %flt_pos, %max_flt_pos
-  %conversion_valid_i32 = sext i1 %conversion_valid to i32
+  %conversion_valid_i32 = zext i1 %conversion_valid to i32
   %1 = fptosi double %"2_01" to i32
   %result_row = insertvalue { i32 } undef, i32 %1, 0
-  %conversion_result = insertvalue { i32, { { i32, i8* } }, { i32 } } { i32 poison, { i32, i8* } { i32 2, i8* getelementptr inbounds ([58 x i8], [58 x i8]* @0, i32 0, i32 0) }, { i32 } poison }, { i32 } %result_row, 2
+  %conversion_result = insertvalue { i32, { { i32, i8* } }, { i32 } } { i32 undef, { i32, i8* } { i32 2, i8* getelementptr inbounds ([58 x i8], [58 x i8]* @0, i32 0, i32 0) }, { i32 } undef }, { i32 } %result_row, 2
   %tag = insertvalue { i32, { { i32, i8* } }, { i32 } } %conversion_result, i32 %conversion_valid_i32, 0
   store { i32, { { i32, i8* } }, { i32 } } %tag, { i32, { { i32, i8* } }, { i32 } }* %"4_0", align 8
   %"4_02" = load { i32, { { i32, i8* } }, { i32 } }, { i32, { { i32, i8* } }, { i32 } }* %"4_0", align 8

--- a/src/custom/snapshots/hugr_llvm__custom__conversions__test__trunc_u@llvm14.snap
+++ b/src/custom/snapshots/hugr_llvm__custom__conversions__test__trunc_u@llvm14.snap
@@ -1,0 +1,17 @@
+---
+source: src/custom/conversions.rs
+expression: module.to_string()
+---
+; ModuleID = 'test_context'
+source_filename = "test_context"
+
+define { i32, { { i32, i8* } }, { i64 } } @_hl.main.1(double %0) {
+alloca_block:
+  br label %entry_block
+
+entry_block:                                      ; preds = %alloca_block
+  %1 = fptoui double %0 to i64
+  %2 = insertvalue { i64 } undef, i64 %1, 0
+  %3 = insertvalue { i32, { { i32, i8* } }, { i64 } } { i32 1, { { i32, i8* } } poison, { i64 } poison }, { i64 } %2, 2
+  ret { i32, { { i32, i8* } }, { i64 } } %3
+}

--- a/src/custom/snapshots/hugr_llvm__custom__conversions__test__trunc_u@llvm14.snap
+++ b/src/custom/snapshots/hugr_llvm__custom__conversions__test__trunc_u@llvm14.snap
@@ -5,13 +5,24 @@ expression: module.to_string()
 ; ModuleID = 'test_context'
 source_filename = "test_context"
 
+@0 = private unnamed_addr constant [58 x i8] c"Float value too big to convert to int of given width (64)\00", align 1
+
 define { i32, { { i32, i8* } }, { i64 } } @_hl.main.1(double %0) {
 alloca_block:
   br label %entry_block
 
 entry_block:                                      ; preds = %alloca_block
+  %flt_pos = call double @llvm.fabs.f64(double %0)
+  %conversion_valid = fcmp ole double %flt_pos, 0x43F0000000000000
+  %conversion_valid_i32 = sext i1 %conversion_valid to i32
   %1 = fptoui double %0 to i64
-  %2 = insertvalue { i64 } undef, i64 %1, 0
-  %3 = insertvalue { i32, { { i32, i8* } }, { i64 } } { i32 1, { { i32, i8* } } poison, { i64 } poison }, { i64 } %2, 2
-  ret { i32, { { i32, i8* } }, { i64 } } %3
+  %result_row = insertvalue { i64 } undef, i64 %1, 0
+  %conversion_result = insertvalue { i32, { { i32, i8* } }, { i64 } } { i32 poison, { i32, i8* } { i32 2, i8* getelementptr inbounds ([58 x i8], [58 x i8]* @0, i32 0, i32 0) }, { i64 } poison }, { i64 } %result_row, 2
+  %tag = insertvalue { i32, { { i32, i8* } }, { i64 } } %conversion_result, i32 %conversion_valid_i32, 0
+  ret { i32, { { i32, i8* } }, { i64 } } %tag
 }
+
+; Function Attrs: nofree nosync nounwind readnone speculatable willreturn
+declare double @llvm.fabs.f64(double) #0
+
+attributes #0 = { nofree nosync nounwind readnone speculatable willreturn }

--- a/src/custom/snapshots/hugr_llvm__custom__conversions__test__trunc_u@llvm14.snap
+++ b/src/custom/snapshots/hugr_llvm__custom__conversions__test__trunc_u@llvm14.snap
@@ -15,11 +15,11 @@ entry_block:                                      ; preds = %alloca_block
   %flt_pos = call double @llvm.fabs.f64(double %0)
   %conversion_valid = fcmp ole double %flt_pos, 0x43F0000000000000
   %conversion_valid_i32 = zext i1 %conversion_valid to i32
-  %1 = fptoui double %0 to i64
-  %result_row = insertvalue { i64 } undef, i64 %1, 0
-  %conversion_result = insertvalue { i32, { { i32, i8* } }, { i64 } } { i32 undef, { i32, i8* } { i32 2, i8* getelementptr inbounds ([58 x i8], [58 x i8]* @0, i32 0, i32 0) }, { i64 } undef }, { i64 } %result_row, 2
-  %tag = insertvalue { i32, { { i32, i8* } }, { i64 } } %conversion_result, i32 %conversion_valid_i32, 0
-  ret { i32, { { i32, i8* } }, { i64 } } %tag
+  %trunc_result = fptoui double %0 to i64
+  %1 = insertvalue { i64 } undef, i64 %trunc_result, 0
+  %2 = insertvalue { i32, { { i32, i8* } }, { i64 } } { i32 1, { { i32, i8* } } poison, { i64 } poison }, { i64 } %1, 2
+  %3 = select i1 %conversion_valid, { i32, { { i32, i8* } }, { i64 } } %2, { i32, { { i32, i8* } }, { i64 } } { i32 0, { { i32, i8* } } { { i32, i8* } { i32 2, i8* getelementptr inbounds ([58 x i8], [58 x i8]* @0, i32 0, i32 0) } }, { i64 } poison }
+  ret { i32, { { i32, i8* } }, { i64 } } %3
 }
 
 ; Function Attrs: nofree nosync nounwind readnone speculatable willreturn

--- a/src/custom/snapshots/hugr_llvm__custom__conversions__test__trunc_u@llvm14.snap
+++ b/src/custom/snapshots/hugr_llvm__custom__conversions__test__trunc_u@llvm14.snap
@@ -1,6 +1,6 @@
 ---
 source: src/custom/conversions.rs
-expression: module.to_string()
+expression: mod_str
 ---
 ; ModuleID = 'test_context'
 source_filename = "test_context"
@@ -14,10 +14,10 @@ alloca_block:
 entry_block:                                      ; preds = %alloca_block
   %flt_pos = call double @llvm.fabs.f64(double %0)
   %conversion_valid = fcmp ole double %flt_pos, 0x43F0000000000000
-  %conversion_valid_i32 = sext i1 %conversion_valid to i32
+  %conversion_valid_i32 = zext i1 %conversion_valid to i32
   %1 = fptoui double %0 to i64
   %result_row = insertvalue { i64 } undef, i64 %1, 0
-  %conversion_result = insertvalue { i32, { { i32, i8* } }, { i64 } } { i32 poison, { i32, i8* } { i32 2, i8* getelementptr inbounds ([58 x i8], [58 x i8]* @0, i32 0, i32 0) }, { i64 } poison }, { i64 } %result_row, 2
+  %conversion_result = insertvalue { i32, { { i32, i8* } }, { i64 } } { i32 undef, { i32, i8* } { i32 2, i8* getelementptr inbounds ([58 x i8], [58 x i8]* @0, i32 0, i32 0) }, { i64 } undef }, { i64 } %result_row, 2
   %tag = insertvalue { i32, { { i32, i8* } }, { i64 } } %conversion_result, i32 %conversion_valid_i32, 0
   ret { i32, { { i32, i8* } }, { i64 } } %tag
 }

--- a/src/custom/snapshots/hugr_llvm__custom__conversions__test__trunc_u@llvm14.snap
+++ b/src/custom/snapshots/hugr_llvm__custom__conversions__test__trunc_u@llvm14.snap
@@ -12,16 +12,12 @@ alloca_block:
   br label %entry_block
 
 entry_block:                                      ; preds = %alloca_block
-  %flt_pos = call double @llvm.fabs.f64(double %0)
-  %conversion_valid = fcmp ole double %flt_pos, 0x43F0000000000000
+  %within_upper_bound = fcmp ole double %0, 0x43F0000000000000
+  %within_lower_bound = fcmp ole double 0.000000e+00, %0
+  %success = and i1 %within_upper_bound, %within_lower_bound
   %trunc_result = fptoui double %0 to i64
   %1 = insertvalue { i64 } undef, i64 %trunc_result, 0
   %2 = insertvalue { i32, { { i32, i8* } }, { i64 } } { i32 1, { { i32, i8* } } poison, { i64 } poison }, { i64 } %1, 2
-  %3 = select i1 %conversion_valid, { i32, { { i32, i8* } }, { i64 } } %2, { i32, { { i32, i8* } }, { i64 } } { i32 0, { { i32, i8* } } { { i32, i8* } { i32 2, i8* getelementptr inbounds ([58 x i8], [58 x i8]* @0, i32 0, i32 0) } }, { i64 } poison }
+  %3 = select i1 %success, { i32, { { i32, i8* } }, { i64 } } %2, { i32, { { i32, i8* } }, { i64 } } { i32 0, { { i32, i8* } } { { i32, i8* } { i32 2, i8* getelementptr inbounds ([58 x i8], [58 x i8]* @0, i32 0, i32 0) } }, { i64 } poison }
   ret { i32, { { i32, i8* } }, { i64 } } %3
 }
-
-; Function Attrs: nofree nosync nounwind readnone speculatable willreturn
-declare double @llvm.fabs.f64(double) #0
-
-attributes #0 = { nofree nosync nounwind readnone speculatable willreturn }

--- a/src/custom/snapshots/hugr_llvm__custom__conversions__test__trunc_u@llvm14.snap
+++ b/src/custom/snapshots/hugr_llvm__custom__conversions__test__trunc_u@llvm14.snap
@@ -14,7 +14,6 @@ alloca_block:
 entry_block:                                      ; preds = %alloca_block
   %flt_pos = call double @llvm.fabs.f64(double %0)
   %conversion_valid = fcmp ole double %flt_pos, 0x43F0000000000000
-  %conversion_valid_i32 = zext i1 %conversion_valid to i32
   %trunc_result = fptoui double %0 to i64
   %1 = insertvalue { i64 } undef, i64 %trunc_result, 0
   %2 = insertvalue { i32, { { i32, i8* } }, { i64 } } { i32 1, { { i32, i8* } } poison, { i64 } poison }, { i64 } %1, 2

--- a/src/custom/snapshots/hugr_llvm__custom__conversions__test__trunc_u@pre-mem2reg@llvm14.snap
+++ b/src/custom/snapshots/hugr_llvm__custom__conversions__test__trunc_u@pre-mem2reg@llvm14.snap
@@ -17,20 +17,16 @@ alloca_block:
 entry_block:                                      ; preds = %alloca_block
   store double %0, double* %"2_0", align 8
   %"2_01" = load double, double* %"2_0", align 8
-  %flt_pos = call double @llvm.fabs.f64(double %"2_01")
-  %conversion_valid = fcmp ole double %flt_pos, 0x43F0000000000000
+  %within_upper_bound = fcmp ole double %"2_01", 0x43F0000000000000
+  %within_lower_bound = fcmp ole double 0.000000e+00, %"2_01"
+  %success = and i1 %within_upper_bound, %within_lower_bound
   %trunc_result = fptoui double %"2_01" to i64
   %1 = insertvalue { i64 } undef, i64 %trunc_result, 0
   %2 = insertvalue { i32, { { i32, i8* } }, { i64 } } { i32 1, { { i32, i8* } } poison, { i64 } poison }, { i64 } %1, 2
-  %3 = select i1 %conversion_valid, { i32, { { i32, i8* } }, { i64 } } %2, { i32, { { i32, i8* } }, { i64 } } { i32 0, { { i32, i8* } } { { i32, i8* } { i32 2, i8* getelementptr inbounds ([58 x i8], [58 x i8]* @0, i32 0, i32 0) } }, { i64 } poison }
+  %3 = select i1 %success, { i32, { { i32, i8* } }, { i64 } } %2, { i32, { { i32, i8* } }, { i64 } } { i32 0, { { i32, i8* } } { { i32, i8* } { i32 2, i8* getelementptr inbounds ([58 x i8], [58 x i8]* @0, i32 0, i32 0) } }, { i64 } poison }
   store { i32, { { i32, i8* } }, { i64 } } %3, { i32, { { i32, i8* } }, { i64 } }* %"4_0", align 8
   %"4_02" = load { i32, { { i32, i8* } }, { i64 } }, { i32, { { i32, i8* } }, { i64 } }* %"4_0", align 8
   store { i32, { { i32, i8* } }, { i64 } } %"4_02", { i32, { { i32, i8* } }, { i64 } }* %"0", align 8
   %"03" = load { i32, { { i32, i8* } }, { i64 } }, { i32, { { i32, i8* } }, { i64 } }* %"0", align 8
   ret { i32, { { i32, i8* } }, { i64 } } %"03"
 }
-
-; Function Attrs: nofree nosync nounwind readnone speculatable willreturn
-declare double @llvm.fabs.f64(double) #0
-
-attributes #0 = { nofree nosync nounwind readnone speculatable willreturn }

--- a/src/custom/snapshots/hugr_llvm__custom__conversions__test__trunc_u@pre-mem2reg@llvm14.snap
+++ b/src/custom/snapshots/hugr_llvm__custom__conversions__test__trunc_u@pre-mem2reg@llvm14.snap
@@ -19,7 +19,6 @@ entry_block:                                      ; preds = %alloca_block
   %"2_01" = load double, double* %"2_0", align 8
   %flt_pos = call double @llvm.fabs.f64(double %"2_01")
   %conversion_valid = fcmp ole double %flt_pos, 0x43F0000000000000
-  %conversion_valid_i32 = zext i1 %conversion_valid to i32
   %trunc_result = fptoui double %"2_01" to i64
   %1 = insertvalue { i64 } undef, i64 %trunc_result, 0
   %2 = insertvalue { i32, { { i32, i8* } }, { i64 } } { i32 1, { { i32, i8* } } poison, { i64 } poison }, { i64 } %1, 2

--- a/src/custom/snapshots/hugr_llvm__custom__conversions__test__trunc_u@pre-mem2reg@llvm14.snap
+++ b/src/custom/snapshots/hugr_llvm__custom__conversions__test__trunc_u@pre-mem2reg@llvm14.snap
@@ -1,0 +1,26 @@
+---
+source: src/custom/conversions.rs
+expression: module.to_string()
+---
+; ModuleID = 'test_context'
+source_filename = "test_context"
+
+define { i32, { { i32, i8* } }, { i64 } } @_hl.main.1(double %0) {
+alloca_block:
+  %"0" = alloca { i32, { { i32, i8* } }, { i64 } }, align 8
+  %"2_0" = alloca double, align 8
+  %"4_0" = alloca { i32, { { i32, i8* } }, { i64 } }, align 8
+  br label %entry_block
+
+entry_block:                                      ; preds = %alloca_block
+  store double %0, double* %"2_0", align 8
+  %"2_01" = load double, double* %"2_0", align 8
+  %1 = fptoui double %"2_01" to i64
+  %2 = insertvalue { i64 } undef, i64 %1, 0
+  %3 = insertvalue { i32, { { i32, i8* } }, { i64 } } { i32 1, { { i32, i8* } } poison, { i64 } poison }, { i64 } %2, 2
+  store { i32, { { i32, i8* } }, { i64 } } %3, { i32, { { i32, i8* } }, { i64 } }* %"4_0", align 8
+  %"4_02" = load { i32, { { i32, i8* } }, { i64 } }, { i32, { { i32, i8* } }, { i64 } }* %"4_0", align 8
+  store { i32, { { i32, i8* } }, { i64 } } %"4_02", { i32, { { i32, i8* } }, { i64 } }* %"0", align 8
+  %"03" = load { i32, { { i32, i8* } }, { i64 } }, { i32, { { i32, i8* } }, { i64 } }* %"0", align 8
+  ret { i32, { { i32, i8* } }, { i64 } } %"03"
+}

--- a/src/custom/snapshots/hugr_llvm__custom__conversions__test__trunc_u@pre-mem2reg@llvm14.snap
+++ b/src/custom/snapshots/hugr_llvm__custom__conversions__test__trunc_u@pre-mem2reg@llvm14.snap
@@ -1,6 +1,6 @@
 ---
 source: src/custom/conversions.rs
-expression: module.to_string()
+expression: mod_str
 ---
 ; ModuleID = 'test_context'
 source_filename = "test_context"
@@ -19,10 +19,10 @@ entry_block:                                      ; preds = %alloca_block
   %"2_01" = load double, double* %"2_0", align 8
   %flt_pos = call double @llvm.fabs.f64(double %"2_01")
   %conversion_valid = fcmp ole double %flt_pos, 0x43F0000000000000
-  %conversion_valid_i32 = sext i1 %conversion_valid to i32
+  %conversion_valid_i32 = zext i1 %conversion_valid to i32
   %1 = fptoui double %"2_01" to i64
   %result_row = insertvalue { i64 } undef, i64 %1, 0
-  %conversion_result = insertvalue { i32, { { i32, i8* } }, { i64 } } { i32 poison, { i32, i8* } { i32 2, i8* getelementptr inbounds ([58 x i8], [58 x i8]* @0, i32 0, i32 0) }, { i64 } poison }, { i64 } %result_row, 2
+  %conversion_result = insertvalue { i32, { { i32, i8* } }, { i64 } } { i32 undef, { i32, i8* } { i32 2, i8* getelementptr inbounds ([58 x i8], [58 x i8]* @0, i32 0, i32 0) }, { i64 } undef }, { i64 } %result_row, 2
   %tag = insertvalue { i32, { { i32, i8* } }, { i64 } } %conversion_result, i32 %conversion_valid_i32, 0
   store { i32, { { i32, i8* } }, { i64 } } %tag, { i32, { { i32, i8* } }, { i64 } }* %"4_0", align 8
   %"4_02" = load { i32, { { i32, i8* } }, { i64 } }, { i32, { { i32, i8* } }, { i64 } }* %"4_0", align 8

--- a/src/custom/snapshots/hugr_llvm__custom__conversions__test__trunc_u@pre-mem2reg@llvm14.snap
+++ b/src/custom/snapshots/hugr_llvm__custom__conversions__test__trunc_u@pre-mem2reg@llvm14.snap
@@ -20,11 +20,11 @@ entry_block:                                      ; preds = %alloca_block
   %flt_pos = call double @llvm.fabs.f64(double %"2_01")
   %conversion_valid = fcmp ole double %flt_pos, 0x43F0000000000000
   %conversion_valid_i32 = zext i1 %conversion_valid to i32
-  %1 = fptoui double %"2_01" to i64
-  %result_row = insertvalue { i64 } undef, i64 %1, 0
-  %conversion_result = insertvalue { i32, { { i32, i8* } }, { i64 } } { i32 undef, { i32, i8* } { i32 2, i8* getelementptr inbounds ([58 x i8], [58 x i8]* @0, i32 0, i32 0) }, { i64 } undef }, { i64 } %result_row, 2
-  %tag = insertvalue { i32, { { i32, i8* } }, { i64 } } %conversion_result, i32 %conversion_valid_i32, 0
-  store { i32, { { i32, i8* } }, { i64 } } %tag, { i32, { { i32, i8* } }, { i64 } }* %"4_0", align 8
+  %trunc_result = fptoui double %"2_01" to i64
+  %1 = insertvalue { i64 } undef, i64 %trunc_result, 0
+  %2 = insertvalue { i32, { { i32, i8* } }, { i64 } } { i32 1, { { i32, i8* } } poison, { i64 } poison }, { i64 } %1, 2
+  %3 = select i1 %conversion_valid, { i32, { { i32, i8* } }, { i64 } } %2, { i32, { { i32, i8* } }, { i64 } } { i32 0, { { i32, i8* } } { { i32, i8* } { i32 2, i8* getelementptr inbounds ([58 x i8], [58 x i8]* @0, i32 0, i32 0) } }, { i64 } poison }
+  store { i32, { { i32, i8* } }, { i64 } } %3, { i32, { { i32, i8* } }, { i64 } }* %"4_0", align 8
   %"4_02" = load { i32, { { i32, i8* } }, { i64 } }, { i32, { { i32, i8* } }, { i64 } }* %"4_0", align 8
   store { i32, { { i32, i8* } }, { i64 } } %"4_02", { i32, { { i32, i8* } }, { i64 } }* %"0", align 8
   %"03" = load { i32, { { i32, i8* } }, { i64 } }, { i32, { { i32, i8* } }, { i64 } }* %"0", align 8

--- a/src/custom/snapshots/hugr_llvm__custom__conversions__test__trunc_u@pre-mem2reg@llvm14.snap
+++ b/src/custom/snapshots/hugr_llvm__custom__conversions__test__trunc_u@pre-mem2reg@llvm14.snap
@@ -21,7 +21,8 @@ entry_block:                                      ; preds = %alloca_block
   %conversion_valid = fcmp ole double %flt_pos, 0x43F0000000000000
   %conversion_valid_i32 = sext i1 %conversion_valid to i32
   %1 = fptoui double %"2_01" to i64
-  %conversion_result = insertvalue { i32, { { i32, i8* } }, { i64 } } { i32 poison, { i32, i8* } { i32 2, i8* getelementptr inbounds ([58 x i8], [58 x i8]* @0, i32 0, i32 0) }, { i64 } poison }, i64 %1, 2
+  %result_row = insertvalue { i64 } undef, i64 %1, 0
+  %conversion_result = insertvalue { i32, { { i32, i8* } }, { i64 } } { i32 poison, { i32, i8* } { i32 2, i8* getelementptr inbounds ([58 x i8], [58 x i8]* @0, i32 0, i32 0) }, { i64 } poison }, { i64 } %result_row, 2
   %tag = insertvalue { i32, { { i32, i8* } }, { i64 } } %conversion_result, i32 %conversion_valid_i32, 0
   store { i32, { { i32, i8* } }, { i64 } } %tag, { i32, { { i32, i8* } }, { i64 } }* %"4_0", align 8
   %"4_02" = load { i32, { { i32, i8* } }, { i64 } }, { i32, { { i32, i8* } }, { i64 } }* %"4_0", align 8

--- a/src/custom/snapshots/hugr_llvm__custom__conversions__test__trunc_u@pre-mem2reg@llvm14.snap
+++ b/src/custom/snapshots/hugr_llvm__custom__conversions__test__trunc_u@pre-mem2reg@llvm14.snap
@@ -5,6 +5,8 @@ expression: module.to_string()
 ; ModuleID = 'test_context'
 source_filename = "test_context"
 
+@0 = private unnamed_addr constant [58 x i8] c"Float value too big to convert to int of given width (64)\00", align 1
+
 define { i32, { { i32, i8* } }, { i64 } } @_hl.main.1(double %0) {
 alloca_block:
   %"0" = alloca { i32, { { i32, i8* } }, { i64 } }, align 8
@@ -15,12 +17,20 @@ alloca_block:
 entry_block:                                      ; preds = %alloca_block
   store double %0, double* %"2_0", align 8
   %"2_01" = load double, double* %"2_0", align 8
+  %flt_pos = call double @llvm.fabs.f64(double %"2_01")
+  %conversion_valid = fcmp ole double %flt_pos, 0x43F0000000000000
+  %conversion_valid_i32 = sext i1 %conversion_valid to i32
   %1 = fptoui double %"2_01" to i64
-  %2 = insertvalue { i64 } undef, i64 %1, 0
-  %3 = insertvalue { i32, { { i32, i8* } }, { i64 } } { i32 1, { { i32, i8* } } poison, { i64 } poison }, { i64 } %2, 2
-  store { i32, { { i32, i8* } }, { i64 } } %3, { i32, { { i32, i8* } }, { i64 } }* %"4_0", align 8
+  %conversion_result = insertvalue { i32, { { i32, i8* } }, { i64 } } { i32 poison, { i32, i8* } { i32 2, i8* getelementptr inbounds ([58 x i8], [58 x i8]* @0, i32 0, i32 0) }, { i64 } poison }, i64 %1, 2
+  %tag = insertvalue { i32, { { i32, i8* } }, { i64 } } %conversion_result, i32 %conversion_valid_i32, 0
+  store { i32, { { i32, i8* } }, { i64 } } %tag, { i32, { { i32, i8* } }, { i64 } }* %"4_0", align 8
   %"4_02" = load { i32, { { i32, i8* } }, { i64 } }, { i32, { { i32, i8* } }, { i64 } }* %"4_0", align 8
   store { i32, { { i32, i8* } }, { i64 } } %"4_02", { i32, { { i32, i8* } }, { i64 } }* %"0", align 8
   %"03" = load { i32, { { i32, i8* } }, { i64 } }, { i32, { { i32, i8* } }, { i64 } }* %"0", align 8
   ret { i32, { { i32, i8* } }, { i64 } } %"03"
 }
+
+; Function Attrs: nofree nosync nounwind readnone speculatable willreturn
+declare double @llvm.fabs.f64(double) #0
+
+attributes #0 = { nofree nosync nounwind readnone speculatable willreturn }

--- a/src/emit/func.rs
+++ b/src/emit/func.rs
@@ -10,6 +10,7 @@ use inkwell::{
     basic_block::BasicBlock,
     builder::Builder,
     context::Context,
+    module::Module,
     types::{BasicType, BasicTypeEnum, FunctionType},
     values::{FunctionValue, GlobalValue},
 };
@@ -279,6 +280,10 @@ impl<'c, H: HugrView> EmitFuncContext<'c, H> {
         )?;
         self.env.insert(wire, mb.clone());
         Ok(mb)
+    }
+
+    pub fn get_current_module(&self) -> &Module<'c> {
+        &self.emit_context.module()
     }
 
     /// Consumes the `EmitFuncContext` and returns both the inner

--- a/src/emit/func.rs
+++ b/src/emit/func.rs
@@ -283,7 +283,7 @@ impl<'c, H: HugrView> EmitFuncContext<'c, H> {
     }
 
     pub fn get_current_module(&self) -> &Module<'c> {
-        &self.emit_context.module()
+        self.emit_context.module()
     }
 
     /// Consumes the `EmitFuncContext` and returns both the inner

--- a/src/emit/ops.rs
+++ b/src/emit/ops.rs
@@ -441,7 +441,7 @@ pub(crate) fn emit_custom_binary_op<'c, H, F>(
 where
     H: HugrView,
     F: FnOnce(
-        &Builder<'c>,
+        &mut EmitFuncContext<'c, H>,
         (BasicValueEnum<'c>, BasicValueEnum<'c>),
         &[BasicTypeEnum<'c>],
     ) -> Result<Vec<BasicValueEnum<'c>>>,
@@ -460,7 +460,7 @@ where
         ));
     }
     let out_types = args.outputs.get_types().collect_vec();
-    let res = go(context.builder(), (lhs, rhs), &out_types)?;
+    let res = go(context, (lhs, rhs), &out_types)?;
     if res.len() != out_types.len() || zip_eq(res.iter(), out_types).any(|(a, b)| a.get_type() != b)
     {
         return Err(anyhow!(

--- a/src/emit/ops.rs
+++ b/src/emit/ops.rs
@@ -400,7 +400,7 @@ pub(crate) fn emit_custom_unary_op<'c, H, F>(
 where
     H: HugrView,
     F: FnOnce(
-        &Builder<'c>,
+        &mut EmitFuncContext<'c, H>,
         BasicValueEnum<'c>,
         &[BasicTypeEnum<'c>],
     ) -> Result<Vec<BasicValueEnum<'c>>>,
@@ -412,7 +412,7 @@ where
         )
     })?;
     let out_types = args.outputs.get_types().collect_vec();
-    let res = go(context.builder(), inp, &out_types)?;
+    let res = go(context, inp, &out_types)?;
     if res.len() != args.outputs.len()
         || zip_eq(res.iter(), out_types).any(|(a, b)| a.get_type() != b)
     {

--- a/src/test.rs
+++ b/src/test.rs
@@ -153,10 +153,10 @@ impl TestContext {
         )
     }
 
-    /// Lower `hugr` to LLVM, then JIT and execute the function named `entry` in
-    /// the inner module.
+    /// Lower `hugr` to LLVM, then JIT and execute the function named
+    /// `entry_point` in the inner module.
     ///
-    /// That function must take no arguments and return an `i64`.
+    /// That function must take no arguments and return an LLVM `i64`.
     pub fn exec_hugr_u64(&self, hugr: THugrView, entry_point: impl AsRef<str>) -> u64 {
         let emission = Emission::emit_hugr(hugr.fat_root().unwrap(), self.get_emit_hugr()).unwrap();
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -154,7 +154,7 @@ impl TestContext {
     }
 
     /// Lower `hugr` to LLVM, then JIT and execute the function named
-    /// `entry_point` in the inner module.
+    /// by `entry_point` in the inner module.
     ///
     /// That function must take no arguments and return an LLVM `i64`.
     pub fn exec_hugr_u64(&self, hugr: THugrView, entry_point: impl AsRef<str>) -> u64 {


### PR DESCRIPTION
Work towards #22, but since we updated to hugr 0.12.0 there are more operations in `arithmetic.conversions`. I'll implement those in a separate PR.