### PR TITLE
fix: remove wildcard (`*`) dependency constraint for crate publishing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -945,18 +945,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.209"
+version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99fce0ffe7310761ca6bf9faf5115afbc19688edd00171d81b1bb1b116c63e09"
+checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.209"
+version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5831b979fd7b5439637af1752d535ff49f4860c0f341d1baeb6faf0f4242170"
+checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,8 +38,8 @@ rstest = "0.19.0"
 portgraph = "0.12.1"
 pathsearch = "0.2.0"
 serde_json = "1.0.117"
-serde = "*"
-typetag = "*"
+serde = "1"
+typetag = "0.2"
 
 [profile.dev.package]
 insta.opt-level = 3

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -28,17 +28,16 @@ shell by setting up [direnv](https://devenv.sh/automatic-shell-activation/).
 
 To set up the environment manually you will need:
 
-- Rust `>=1.75`: https://www.rust-lang.org/tools/install
-- llvm `== 14.0`: we use the rust bindings 
-[llvm-sys](https://crates.io/crates/llvm-sys) to [llvm](https://llvm.org/), 
-- Poetry `>=1.8`: https://python-poetry.org/
+- Rust `>=1.75`: <https://www.rust-lang.org/tools/install>
+- llvm `== 14.0`: we use the rust bindings
+[llvm-sys](https://crates.io/crates/llvm-sys) to [llvm](https://llvm.org/),
+- Poetry `>=1.8`: <https://python-poetry.org/>
 
 Once you have these installed, verify that your setup is working
 
 ```bash
 cargo test
 ```
-
 
 ## 💅 Coding Style
 
@@ -51,7 +50,6 @@ cargo format
 ```
 
 We also use various linters to catch common mistakes and enforce best practices. To run these, see [our CI config](./.github/workflows/ci-rs.yml). TODO Provide a better way, contributions welcome.
-
 
 ## 📈 Code Coverage
 

--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@
 [![codecov](https://codecov.io/github/CQCL/hugr-llvm/graph/badge.svg?token=TN3DSNHF43)](https://codecov.io/github/CQCL/hugr-llvm)
 [![msrv][]](https://github.com/CQCL/hugr-llvm)
 
-
 A general, extensible, rust crate for lowering `HUGR`s into `LLVM` IR. Built on [hugr][], [inkwell][], and [llvm][].
 
 ## Usage
 
 You'll need to point your `Cargo.toml` to use a single LLVM version feature flag corresponding to your LLVM version, by calling
+
 ```bash
 cargo add hugr-llvm --features llvm14-0
 ```
@@ -18,7 +18,7 @@ At present only `llvm14-0` is supported but we expect to introduce supported ver
 
 See the [llvm-sys][] crate for details on how to use your preferred llvm installation.
 
-For an example lowering [guppy][] programs to LLVM see [tests/guppy.rs](./tests/guppy.rs) 
+For an example lowering [guppy][] programs to LLVM see [tests/guppy.rs](./tests/guppy.rs)
 
 ## Recent Changes
 
@@ -31,8 +31,7 @@ See [DEVELOPMENT](DEVELOPMENT.md) for instructions on setting up the development
 
 ## License
 
-This project is licensed under Apache License, Version 2.0 ([LICENCE](LICENCE) or http://www.apache.org/licenses/LICENSE-2.0).
-
+This project is licensed under Apache License, Version 2.0 ([LICENCE](LICENCE) or <http://www.apache.org/licenses/LICENSE-2.0>).
 
   [build_status]: https://github.com/CQCL/hugr-llvm/actions/workflows/ci-rs.yml/badge.svg?branch=main
   [msrv]: https://img.shields.io/badge/rust-1.75.0%2B-blue.svg


### PR DESCRIPTION
Also sanitizes the READMEs a bit.

The last attempt to publish a crate using release PR #98 [failed](https://github.com/CQCL/hugr-llvm/actions/runs/10886782954/job/30207610938) with:
```
error: failed to publish to registry at https://crates.io/
    
    Caused by:
      the remote server responded with an error (status 400 Bad Request): wildcard (`*`) dependency constraints are not allowed on crates.io. Crate with this problem: `serde` See https://doc.rust-lang.org/cargo/faq.html#can-libraries-use--as-a-version-for-their-dependencies for more information
```