### PR TITLE
feat!: Allow extension callbacks to have non-`'static` lifetimes

### DIFF
--- a/src/custom/extension_op.rs
+++ b/src/custom/extension_op.rs
@@ -35,7 +35,7 @@ use crate::emit::{EmitFuncContext, EmitOpArgs};
 ///
 /// Callbacks may hold references with lifetimes older than `'a`.
 pub trait ExtensionOpFn<'a, H>:
-    for<'c> Fn(&mut EmitFuncContext<'c, H>, EmitOpArgs<'c, '_, ExtensionOp, H>) -> Result<()> + 'a
+    for<'c> Fn(&mut EmitFuncContext<'c, 'a, H>, EmitOpArgs<'c, '_, ExtensionOp, H>) -> Result<()> + 'a
 {
 }
 
@@ -43,7 +43,7 @@ impl<
         'a,
         H,
         F: for<'c> Fn(
-                &mut EmitFuncContext<'c, H>,
+                &mut EmitFuncContext<'c, 'a, H>,
                 EmitOpArgs<'c, '_, ExtensionOp, H>,
             ) -> Result<()>
             + ?Sized
@@ -76,7 +76,7 @@ impl<'a, H: HugrView> ExtensionOpMap<'a, H> {
         &mut self,
         handler: impl 'a
             + for<'c> Fn(
-                &mut EmitFuncContext<'c, H>,
+                &mut EmitFuncContext<'c, 'a, H>,
                 EmitOpArgs<'c, '_, ExtensionOp, H>,
                 Op,
             ) -> Result<()>,
@@ -96,7 +96,7 @@ impl<'a, H: HugrView> ExtensionOpMap<'a, H> {
     /// If no handler is registered for the op an error will be returned.
     pub fn emit_extension_op<'c>(
         &self,
-        context: &mut EmitFuncContext<'c, H>,
+        context: &mut EmitFuncContext<'c, 'a, H>,
         args: EmitOpArgs<'c, '_, ExtensionOp, H>,
     ) -> Result<()> {
         let node = args.node();

--- a/src/custom/load_constant.rs
+++ b/src/custom/load_constant.rs
@@ -19,7 +19,7 @@ use crate::emit::EmitFuncContext;
 ///
 /// Callbacks may hold references with lifetimes older than `'a`.
 pub trait LoadConstantFn<'a, H: ?Sized, CC: CustomConst + ?Sized>:
-    for<'c> Fn(&mut EmitFuncContext<'c, H>, &CC) -> Result<BasicValueEnum<'c>> + 'a
+    for<'c> Fn(&mut EmitFuncContext<'c, 'a, H>, &CC) -> Result<BasicValueEnum<'c>> + 'a
 {
 }
 
@@ -27,7 +27,9 @@ impl<
         'a,
         H: ?Sized,
         CC: ?Sized + CustomConst,
-        F: 'a + ?Sized + for<'c> Fn(&mut EmitFuncContext<'c, H>, &CC) -> Result<BasicValueEnum<'c>>,
+        F: 'a
+            + ?Sized
+            + for<'c> Fn(&mut EmitFuncContext<'c, 'a, H>, &CC) -> Result<BasicValueEnum<'c>>,
     > LoadConstantFn<'a, H, CC> for F
 {
 }
@@ -59,7 +61,7 @@ impl<'a, H: HugrView> LoadConstantsMap<'a, H> {
     /// appropriate inner callbacks.
     pub fn emit_load_constant<'c>(
         &self,
-        context: &mut EmitFuncContext<'c, H>,
+        context: &mut EmitFuncContext<'c, 'a, H>,
         konst: &dyn CustomConst,
     ) -> Result<BasicValueEnum<'c>> {
         let type_id = konst.type_id();

--- a/src/emit/ops/cfg.rs
+++ b/src/emit/ops/cfg.rs
@@ -34,7 +34,7 @@ impl<'c, 'hugr, H: HugrView> CfgEmitter<'c, 'hugr, H> {
     // the children in the llvm function. Note that this does not move the
     // position of the builder.
     pub fn new<'d>(
-        context: &'d mut EmitFuncContext<'c, H>,
+        context: &'d mut EmitFuncContext<'c, '_, H>,
         args: EmitOpArgs<'c, 'hugr, CFG, H>,
     ) -> Result<Self>
     where
@@ -95,7 +95,7 @@ impl<'c, 'hugr, H: HugrView> CfgEmitter<'c, 'hugr, H> {
 
     /// Consume the emitter by emitting each child of the node.
     /// After returning the builder will be at the end of the exit block.
-    pub fn emit_children(mut self, context: &mut EmitFuncContext<'c, H>) -> Result<()> {
+    pub fn emit_children(mut self, context: &mut EmitFuncContext<'c, '_, H>) -> Result<()> {
         // write the inputs of the cfg node into the inputs of the entry
         // dataflowblock node, and then branch to the basic block of that entry
         // node.
@@ -146,7 +146,7 @@ impl<'c, 'hugr, H: HugrView> CfgEmitter<'c, 'hugr, H> {
     }
     fn emit_dataflow_block(
         &mut self,
-        context: &mut EmitFuncContext<'c, H>,
+        context: &mut EmitFuncContext<'c, '_, H>,
         EmitOpArgs {
             node,
             inputs: _,
@@ -203,7 +203,7 @@ impl<'c, 'hugr, H: HugrView> CfgEmitter<'c, 'hugr, H> {
 
     fn emit_exit_block(
         &mut self,
-        context: &mut EmitFuncContext<'c, H>,
+        context: &mut EmitFuncContext<'c, '_, H>,
         args: EmitOpArgs<'c, 'hugr, ExitBlock, H>,
     ) -> Result<()> {
         let outputs = self.take_outputs()?;

--- a/src/emit/test.rs
+++ b/src/emit/test.rs
@@ -44,9 +44,9 @@ pub struct Emission<'c> {
 
 impl<'c> Emission<'c> {
     /// Create an `Emission` from a HUGR.
-    pub fn emit_hugr<H: HugrView>(
+    pub fn emit_hugr<'a: 'c, H: HugrView>(
         hugr: FatNode<'c, hugr::ops::Module, H>,
-        eh: EmitHugr<'c, H>,
+        eh: EmitHugr<'c, 'a, H>,
     ) -> Result<Self> where {
         let module = eh.emit_module(hugr)?.finish();
         Ok(Self { module })

--- a/src/extension/conversions.rs
+++ b/src/extension/conversions.rs
@@ -24,7 +24,7 @@ use crate::{
 };
 
 fn build_trunc_op<'c, H: HugrView>(
-    context: &mut EmitFuncContext<'c, H>,
+    context: &mut EmitFuncContext<'c, '_, H>,
     signed: bool,
     log_width: u64,
     args: EmitOpArgs<'c, '_, ExtensionOp, H>,
@@ -129,7 +129,7 @@ fn build_trunc_op<'c, H: HugrView>(
 }
 
 fn emit_conversion_op<'c, H: HugrView>(
-    context: &mut EmitFuncContext<'c, H>,
+    context: &mut EmitFuncContext<'c, '_, H>,
     args: EmitOpArgs<'c, '_, ExtensionOp, H>,
     conversion_op: ConvertOpDef,
 ) -> Result<()> {

--- a/src/extension/float.rs
+++ b/src/extension/float.rs
@@ -19,7 +19,7 @@ use crate::custom::CodegenExtsBuilder;
 
 /// Emit a float comparison operation.
 fn emit_fcmp<'c, H: HugrView>(
-    context: &mut EmitFuncContext<'c, H>,
+    context: &mut EmitFuncContext<'c, '_, H>,
     args: EmitOpArgs<'c, '_, ExtensionOp, H>,
     pred: inkwell::FloatPredicate,
 ) -> Result<()> {
@@ -42,7 +42,7 @@ fn emit_fcmp<'c, H: HugrView>(
 }
 
 fn emit_float_op<'c, H: HugrView>(
-    context: &mut EmitFuncContext<'c, H>,
+    context: &mut EmitFuncContext<'c, '_, H>,
     args: EmitOpArgs<'c, '_, ExtensionOp, H>,
     op: FloatOps,
 ) -> Result<()> {
@@ -101,7 +101,7 @@ fn emit_float_op<'c, H: HugrView>(
 }
 
 fn emit_constf64<'c, H: HugrView>(
-    context: &mut EmitFuncContext<'c, H>,
+    context: &mut EmitFuncContext<'c, '_, H>,
     k: &ConstF64,
 ) -> Result<BasicValueEnum<'c>> {
     let ty: FloatType = context.llvm_type(&k.get_type())?.try_into().unwrap();

--- a/src/extension/int.rs
+++ b/src/extension/int.rs
@@ -25,7 +25,7 @@ use anyhow::{anyhow, Result};
 
 /// Emit an integer comparison operation.
 fn emit_icmp<'c, H: HugrView>(
-    context: &mut EmitFuncContext<'c, H>,
+    context: &mut EmitFuncContext<'c, '_, H>,
     args: EmitOpArgs<'c, '_, ExtensionOp, H>,
     pred: inkwell::IntPredicate,
 ) -> Result<()> {
@@ -48,7 +48,7 @@ fn emit_icmp<'c, H: HugrView>(
 }
 
 fn emit_int_op<'c, H: HugrView>(
-    context: &mut EmitFuncContext<'c, H>,
+    context: &mut EmitFuncContext<'c, '_, H>,
     args: EmitOpArgs<'c, '_, ExtensionOp, H>,
     op: IntOpDef,
 ) -> Result<()> {
@@ -108,7 +108,10 @@ fn emit_int_op<'c, H: HugrView>(
     }
 }
 
-fn llvm_type<'c>(context: TypingSession<'c>, hugr_type: &CustomType) -> Result<BasicTypeEnum<'c>> {
+fn llvm_type<'c>(
+    context: TypingSession<'c, '_>,
+    hugr_type: &CustomType,
+) -> Result<BasicTypeEnum<'c>> {
     if let [TypeArg::BoundedNat { n }] = hugr_type.args() {
         let m = *n as usize;
         if m < int_types::INT_TYPES.len() && int_types::INT_TYPES[m] == hugr_type.clone().into() {
@@ -132,7 +135,7 @@ fn llvm_type<'c>(context: TypingSession<'c>, hugr_type: &CustomType) -> Result<B
 }
 
 fn emit_const_int<'c, H: HugrView>(
-    context: &mut EmitFuncContext<'c, H>,
+    context: &mut EmitFuncContext<'c, '_, H>,
     k: &ConstInt,
 ) -> Result<BasicValueEnum<'c>> {
     let ty: IntType = context.llvm_type(&k.get_type())?.try_into().unwrap();

--- a/src/extension/logic.rs
+++ b/src/extension/logic.rs
@@ -16,7 +16,7 @@ use crate::{
 use anyhow::{anyhow, Result};
 
 fn emit_logic_op<'c, H: HugrView>(
-    context: &mut EmitFuncContext<'c, H>,
+    context: &mut EmitFuncContext<'c, '_, H>,
     args: EmitOpArgs<'c, '_, ExtensionOp, H>,
 ) -> Result<()> {
     let lot = LogicOp::from_optype(&args.node().generalise()).ok_or(anyhow!(

--- a/src/extension/prelude.rs
+++ b/src/extension/prelude.rs
@@ -45,19 +45,19 @@ pub mod array;
 pub trait PreludeCodegen: Clone {
     /// Return the llvm type of [hugr::extension::prelude::USIZE_T]. That type
     /// must be an [IntType].
-    fn usize_type<'c>(&self, session: &TypingSession<'c>) -> IntType<'c> {
+    fn usize_type<'c>(&self, session: &TypingSession<'c, '_>) -> IntType<'c> {
         session.iw_context().i64_type()
     }
 
     /// Return the llvm type of [hugr::extension::prelude::QB_T].
-    fn qubit_type<'c>(&self, session: &TypingSession<'c>) -> impl BasicType<'c> {
+    fn qubit_type<'c>(&self, session: &TypingSession<'c, '_>) -> impl BasicType<'c> {
         session.iw_context().i16_type()
     }
 
     /// Return the llvm type of [hugr::extension::prelude::array_type].
     fn array_type<'c>(
         &self,
-        _session: &TypingSession<'c>,
+        _session: &TypingSession<'c, '_>,
         elem_ty: BasicTypeEnum<'c>,
         size: u64,
     ) -> impl BasicType<'c> {
@@ -67,7 +67,7 @@ pub trait PreludeCodegen: Clone {
     /// Emit a [hugr::extension::prelude::ArrayOp].
     fn emit_array_op<'c, H: HugrView>(
         &self,
-        ctx: &mut EmitFuncContext<'c, H>,
+        ctx: &mut EmitFuncContext<'c, '_, H>,
         op: ArrayOp,
         inputs: Vec<BasicValueEnum<'c>>,
         outputs: RowPromise<'c>,
@@ -310,11 +310,11 @@ mod test {
     #[derive(Clone)]
     struct TestPreludeCodegen;
     impl PreludeCodegen for TestPreludeCodegen {
-        fn usize_type<'c>(&self, session: &TypingSession<'c>) -> IntType<'c> {
+        fn usize_type<'c>(&self, session: &TypingSession<'c, '_>) -> IntType<'c> {
             session.iw_context().i32_type()
         }
 
-        fn qubit_type<'c>(&self, session: &TypingSession<'c>) -> impl BasicType<'c> {
+        fn qubit_type<'c>(&self, session: &TypingSession<'c, '_>) -> impl BasicType<'c> {
             session.iw_context().f64_type()
         }
     }

--- a/src/extension/prelude/array.rs
+++ b/src/extension/prelude/array.rs
@@ -50,7 +50,7 @@ fn with_array_alloca<'c, T, E: From<BuilderError>>(
 
 pub fn emit_array_op<'c, H: HugrView>(
     pcg: &impl PreludeCodegen,
-    ctx: &mut EmitFuncContext<'c, H>,
+    ctx: &mut EmitFuncContext<'c, '_, H>,
     op: ArrayOp,
     inputs: Vec<BasicValueEnum<'c>>,
     outputs: RowPromise<'c>,
@@ -340,7 +340,7 @@ pub fn emit_array_op<'c, H: HugrView>(
 /// Helper function to emit the pop operations.
 fn emit_pop_op<'c>(
     builder: &Builder<'c>,
-    ts: &TypingSession<'c>,
+    ts: &TypingSession<'c, '_>,
     elem_ty: HugrType,
     size: u64,
     array_v: ArrayValue<'c>,

--- a/src/extension/rotation.rs
+++ b/src/extension/rotation.rs
@@ -18,12 +18,12 @@ use tket2::extension::rotation::{
 /// We lower [ROTATION_CUSTOM_TYPE] to an `f64`, representing a number of half-turns.
 pub struct RotationCodegenExtension;
 
-fn llvm_angle_type<'c>(ts: &TypingSession<'c>) -> FloatType<'c> {
+fn llvm_angle_type<'c>(ts: &TypingSession<'c, '_>) -> FloatType<'c> {
     ts.iw_context().f64_type()
 }
 
 fn emit_rotation_op<'c, H: HugrView>(
-    context: &mut EmitFuncContext<'c, H>,
+    context: &mut EmitFuncContext<'c, '_, H>,
     args: EmitOpArgs<'c, '_, ExtensionOp, H>,
     op: RotationOp,
 ) -> Result<()> {
@@ -135,7 +135,7 @@ fn emit_rotation_op<'c, H: HugrView>(
 }
 
 fn emit_const_rotation<'c, H: HugrView>(
-    context: &mut EmitFuncContext<'c, H>,
+    context: &mut EmitFuncContext<'c, '_, H>,
     rotation: &ConstRotation,
 ) -> Result<BasicValueEnum<'c>> {
     let angle_ty = llvm_angle_type(&context.typing_session());
@@ -298,7 +298,7 @@ mod test {
         cem: CodegenExtsBuilder<'a, H>,
     ) -> CodegenExtsBuilder<'a, H> {
         fn emit_nonfinite_const<'c, H: HugrView>(
-            context: &mut EmitFuncContext<'c, H>,
+            context: &mut EmitFuncContext<'c, '_, H>,
             konst: &NonFiniteConst64,
         ) -> Result<BasicValueEnum<'c>> {
             Ok(context.iw_context().f64_type().const_float(konst.0).into())

--- a/src/sum.rs
+++ b/src/sum.rs
@@ -50,7 +50,7 @@ impl<'c> LLVMSumType<'c> {
         Ok(Self(context.struct_type(&types, false), sum_type.clone()))
     }
     /// Attempt to create a new `LLVMSumType` from a [HugrSumType].
-    pub fn try_new(session: &TypingSession<'c>, sum_type: HugrSumType) -> Result<Self> {
+    pub fn try_new(session: &TypingSession<'c, '_>, sum_type: HugrSumType) -> Result<Self> {
         assert!(sum_type.num_variants() < u32::MAX as usize);
         let variants = (0..sum_type.num_variants())
             .map(|i| {

--- a/src/test.rs
+++ b/src/test.rs
@@ -123,11 +123,11 @@ impl TestContext {
         &self.context
     }
 
-    pub fn get_typing_session(&self) -> TypingSession {
+    pub fn get_typing_session(&self) -> TypingSession<'_, 'static> {
         self.type_converter().session(&self.context)
     }
 
-    pub fn get_emit_hugr(&'_ self) -> EmitHugr<'_, THugrView> {
+    pub fn get_emit_hugr(&'_ self) -> EmitHugr<'_, 'static, THugrView> {
         let ctx = self.iw_context();
         let m = ctx.create_module("test_context");
         let exts = self.extensions();
@@ -138,7 +138,7 @@ impl TestContext {
         self.namer = namer;
     }
 
-    pub fn get_emit_module_context(&'_ self) -> EmitModuleContext<'_, THugrView> {
+    pub fn get_emit_module_context(&'_ self) -> EmitModuleContext<'_, 'static, THugrView> {
         let ctx = self.iw_context();
         let m = ctx.create_module("test_context");
         EmitModuleContext::new(


### PR DESCRIPTION
Closes #127.

BREAKING CHANGE: Add a lifetime argument to `TypingSession`, `EmitModuleContext`, `EmitHugr`, `EmitFuncContext`.