### PR TITLE
chore: update devenv

### DIFF
--- a/devenv.lock
+++ b/devenv.lock
@@ -3,11 +3,11 @@
     "devenv": {
       "locked": {
         "dir": "src/modules",
-        "lastModified": 1721817837,
+        "lastModified": 1729445229,
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "44bfc26843694ab17ebae1d4922065e48d93f501",
-        "treeHash": "62b4ad814fcc952c5660916c9cdadc34927b3330",
+        "rev": "006016cf4191c34c17cfdb6669e0690e24302ac0",
+        "treeHash": "07886ed629d5a2370f97cdb17535c15f5b207340",
         "type": "github"
       },
       "original": {
@@ -25,11 +25,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1721889009,
+        "lastModified": 1729492502,
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "41b1295b666f7349cd80daaca53b72a672b90963",
-        "treeHash": "119ebe641a4a66e1bee7d162ae10ee0eb3386403",
+        "rev": "4002a1ec3486b855f341d2b864ba06b61e73af28",
+        "treeHash": "be450b24ea93a1efbba0af720838311f8d8caa5a",
         "type": "github"
       },
       "original": {
@@ -93,11 +93,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1721686456,
+        "lastModified": 1729307008,
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "575f3027caa1e291d24f1e9fb0e3a19c2f26d96b",
-        "treeHash": "ae2b90d07867bf9f121208c0073a311669762314",
+        "rev": "a9b86fc2290b69375c5542b622088eb6eca2a7c3",
+        "treeHash": "d69baa2b9b201e9908fcfe7334dbd475a4d8f836",
         "type": "github"
       },
       "original": {
@@ -117,11 +117,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1721042469,
+        "lastModified": 1729104314,
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "f451c19376071a90d8c58ab1a953c6e9840527fd",
-        "treeHash": "91f40b7a3b9f6886bd77482cba5b5cd890415a2e",
+        "rev": "3c3e88f0f544d6bb54329832616af7eb971b6be6",
+        "treeHash": "fcd9fedafcdf4143e0234378437eed0556df9c51",
         "type": "github"
       },
       "original": {
@@ -141,11 +141,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1721815858,
+        "lastModified": 1729454508,
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "eeb192b79aeac47b40add66347022af17a74fbaf",
-        "treeHash": "015cb860be190226516afcf329140938101df4e4",
+        "rev": "9323b5385863739d1c113f02e4cf3f2777c09977",
+        "treeHash": "d7979c5a855210ea6eabd8f37bd5fcd3364d4fb4",
         "type": "github"
       },
       "original": {

--- a/src/emit/args.rs
+++ b/src/emit/args.rs
@@ -16,7 +16,7 @@ pub struct EmitOpArgs<'c, 'hugr, OT, H> {
     pub outputs: RowPromise<'c>,
 }
 
-impl<'c, 'hugr, OT, H> EmitOpArgs<'c, 'hugr, OT, H> {
+impl<'hugr, OT, H> EmitOpArgs<'_, 'hugr, OT, H> {
     /// Get the internal [FatNode]
     pub fn node(&self) -> FatNode<'hugr, OT, H> {
         self.node

--- a/src/sum.rs
+++ b/src/sum.rs
@@ -159,13 +159,13 @@ impl<'c> From<LLVMSumType<'c>> for BasicTypeEnum<'c> {
     }
 }
 
-impl<'c> std::fmt::Display for LLVMSumType<'c> {
+impl std::fmt::Display for LLVMSumType<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         self.0.fmt(f)
     }
 }
 
-unsafe impl<'c> AsTypeRef for LLVMSumType<'c> {
+unsafe impl AsTypeRef for LLVMSumType<'_> {
     fn as_type_ref(&self) -> inkwell::llvm_sys::prelude::LLVMTypeRef {
         self.0.as_type_ref()
     }
@@ -186,7 +186,7 @@ impl<'c> From<LLVMSumValue<'c>> for BasicValueEnum<'c> {
     }
 }
 
-unsafe impl<'c> AsValueRef for LLVMSumValue<'c> {
+unsafe impl AsValueRef for LLVMSumValue<'_> {
     fn as_value_ref(&self) -> inkwell::llvm_sys::prelude::LLVMValueRef {
         self.0.as_value_ref()
     }

--- a/src/utils/fat.rs
+++ b/src/utils/fat.rs
@@ -289,7 +289,7 @@ impl<OT, H> Clone for FatNode<'_, OT, H> {
     }
 }
 
-impl<'hugr, OT: NamedOp, H: HugrView + ?Sized> std::fmt::Display for FatNode<'hugr, OT, H>
+impl<OT: NamedOp, H: HugrView + ?Sized> std::fmt::Display for FatNode<'_, OT, H>
 where
     for<'a> &'a OpType: TryInto<&'a OT>,
 {


### PR DESCRIPTION
Note that updating `rustc` caused several errors, which are fixed here. New clippy suggestions are also applied.